### PR TITLE
9903 rich text logs emails

### DIFF
--- a/app/views/notification_mailer/new_log.html.erb
+++ b/app/views/notification_mailer/new_log.html.erb
@@ -27,7 +27,10 @@
       <p><%=raw @log.private_notes %></p>
     <% end -%>
 
-    <%= link_to("Timeline for #{@log.project.display_name}", admin_loan_url(@log.project) + "/timeline") %>
+    <p><b>View the log on Madeline:</b></p>
+
+    <p><b>Logs:</b> <%= link_to(admin_loan_url(@log.project) + "/logs", admin_loan_url(@log.project) + "/logs") %></p>
+    <p><b>Timeline:</b> <%= link_to( admin_loan_url(@log.project) + "/timeline", admin_loan_url(@log.project) + "/timeline") %></p>
 
     <p><%= t('notification_mailer.new_log.contact') %></p>
   </body>

--- a/app/views/notification_mailer/new_log.html.erb
+++ b/app/views/notification_mailer/new_log.html.erb
@@ -27,7 +27,7 @@
       <p><%=raw @log.private_notes %></p>
     <% end -%>
 
-    <%= admin_loan_url(@log.project) %>/timeline
+    <%= link_to("Timeline for #{@log.project.display_name}", admin_loan_url(@log.project) + "/timeline") %>
 
     <p><%= t('notification_mailer.new_log.contact') %></p>
   </body>

--- a/app/views/notification_mailer/new_log.html.erb
+++ b/app/views/notification_mailer/new_log.html.erb
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p><%= t('notification_mailer.new_log.created', project: @log.project.display_name, agent: @log.agent.name) %>:</p>
+
+    <p><b><%= t :step %>:</b> <%= @log.project_step.summary %></p>
+
+    <p><b><%= t :status %>:</b> <%= @log.progress_metric %></p>
+
+    <p><b><%= t :summary %>:</b> <%= @log.summary -%></p>
+
+    <% if @log.details.present? -%>
+      <p><b><%= t :details %>:</b></p>
+      <p><%=raw @log.details %></p>
+    <% end -%>
+
+    <% if @log.additional_notes.present? -%>
+      <p><b><%= t 'log.additional_notes' %>:</b></p>
+      <p><%=raw @log.additional_notes %></p>
+    <% end -%>
+
+    <% if @log.private_notes.present? -%>
+      <p><b><%= t 'log.private_notes' %>:</b></p>
+      <p><%=raw @log.private_notes %></p>
+    <% end -%>
+
+    <%= admin_loan_url(@log.project) %>/timeline
+
+    <p><%= t('notification_mailer.new_log.contact') %></p>
+  </body>
+</html>

--- a/app/views/notification_mailer/new_log.html.erb
+++ b/app/views/notification_mailer/new_log.html.erb
@@ -27,10 +27,10 @@
       <p><%=raw @log.private_notes %></p>
     <% end %>
 
-    <p><b><%= t('notification_mailer.new_log.view_on_site.html') %></b></p>
+    <p><b><%= t('notification_mailer.new_log.view_on_site.html') %>:</b></p>
 
-    <p><b><%= t('notification_mailer.new_log.logs') %></b> <%= link_to(admin_loan_url(@log.project) + "/logs", admin_loan_url(@log.project) + "/logs") %></p>
-    <p><b><%= t('notification_mailer.new_log.timeline') %></b> <%= link_to( admin_loan_url(@log.project) + "/timeline", admin_loan_url(@log.project) + "/timeline") %></p>
+    <p><b><%= t('notification_mailer.new_log.logs') %>:</b> <%= link_to(admin_loan_url(@log.project) + "/logs", admin_loan_url(@log.project) + "/logs") %></p>
+    <p><b><%= t('notification_mailer.new_log.timeline') %>:</b> <%= link_to( admin_loan_url(@log.project) + "/timeline", admin_loan_url(@log.project) + "/timeline") %></p>
 
     <p><%= t('notification_mailer.new_log.contact') %></p>
   </body>

--- a/app/views/notification_mailer/new_log.html.erb
+++ b/app/views/notification_mailer/new_log.html.erb
@@ -27,7 +27,7 @@
       <p><%=raw @log.private_notes %></p>
     <% end -%>
 
-    <p><b>View the log on Madeline:</b></p>
+    <p><b><%= t('notification_mailer.view_on_site.html') %></b></p>
 
     <p><b>Logs:</b> <%= link_to(admin_loan_url(@log.project) + "/logs", admin_loan_url(@log.project) + "/logs") %></p>
     <p><b>Timeline:</b> <%= link_to( admin_loan_url(@log.project) + "/timeline", admin_loan_url(@log.project) + "/timeline") %></p>

--- a/app/views/notification_mailer/new_log.html.erb
+++ b/app/views/notification_mailer/new_log.html.erb
@@ -12,25 +12,25 @@
 
     <p><b><%= t :summary %>:</b> <%= @log.summary -%></p>
 
-    <% if @log.details.present? -%>
+    <% if @log.details.present? %>
       <p><b><%= t :details %>:</b></p>
       <p><%=raw @log.details %></p>
-    <% end -%>
+    <% end %>
 
-    <% if @log.additional_notes.present? -%>
+    <% if @log.additional_notes.present? %>
       <p><b><%= t 'log.additional_notes' %>:</b></p>
       <p><%=raw @log.additional_notes %></p>
-    <% end -%>
+    <% end %>
 
-    <% if @log.private_notes.present? -%>
+    <% if @log.private_notes.present? %>
       <p><b><%= t 'log.private_notes' %>:</b></p>
       <p><%=raw @log.private_notes %></p>
-    <% end -%>
+    <% end %>
 
-    <p><b><%= t('notification_mailer.view_on_site.html') %></b></p>
+    <p><b><%= t('notification_mailer.new_log.view_on_site.html') %></b></p>
 
-    <p><b>Logs:</b> <%= link_to(admin_loan_url(@log.project) + "/logs", admin_loan_url(@log.project) + "/logs") %></p>
-    <p><b>Timeline:</b> <%= link_to( admin_loan_url(@log.project) + "/timeline", admin_loan_url(@log.project) + "/timeline") %></p>
+    <p><b><%= t('notification_mailer.new_log.logs') %></b> <%= link_to(admin_loan_url(@log.project) + "/logs", admin_loan_url(@log.project) + "/logs") %></p>
+    <p><b><%= t('notification_mailer.new_log.timeline') %></b> <%= link_to( admin_loan_url(@log.project) + "/timeline", admin_loan_url(@log.project) + "/timeline") %></p>
 
     <p><%= t('notification_mailer.new_log.contact') %></p>
   </body>

--- a/app/views/notification_mailer/new_log.text.erb
+++ b/app/views/notification_mailer/new_log.text.erb
@@ -4,24 +4,12 @@
 
 <%= t :status %>: <%= @log.progress_metric %>
 
-<%= t :summary %>: <%= @log.summary -%>
+<%= t :summary %>: <%= @log.summary %>
 
-<% if @log.details.present? -%>
+To view the log details, additional notes, and private notes, view the log on Madeline:
 
-<%= t :details %>:
-<%= @log.details %>
-<% end -%>
-<% if @log.additional_notes.present? -%>
+Logs: <%= admin_loan_url(@log.project) %>/logs
 
-<%= t 'log.additional_notes' %>:
-<%= @log.additional_notes %>
-<% end -%>
-<% if @log.private_notes.present? -%>
-
-<%= t 'log.private_notes' %>:
-<%= @log.private_notes %>
-<% end -%>
-
-<%= admin_loan_url(@log.project) %>/timeline
+Timeline: <%= admin_loan_url(@log.project) %>/timeline
 
 <%= t('notification_mailer.new_log.contact') %>

--- a/app/views/notification_mailer/new_log.text.erb
+++ b/app/views/notification_mailer/new_log.text.erb
@@ -6,10 +6,10 @@
 
 <%= t :summary %>: <%= @log.summary %>
 
-<%= t('notification_mailer.view_on_site.plain_text') %>
+<%= t('notification_mailer.new_log.view_on_site.plain_text') %>
 
-Logs: <%= admin_loan_url(@log.project) %>/logs
+<%= t('notification_mailer.new_log.logs') %> <%= admin_loan_url(@log.project) %>/logs
 
-Timeline: <%= admin_loan_url(@log.project) %>/timeline
+<%= t('notification_mailer.new_log.timeline') %> <%= admin_loan_url(@log.project) %>/timeline
 
 <%= t('notification_mailer.new_log.contact') %>

--- a/app/views/notification_mailer/new_log.text.erb
+++ b/app/views/notification_mailer/new_log.text.erb
@@ -6,7 +6,7 @@
 
 <%= t :summary %>: <%= @log.summary %>
 
-To view the log's details, additional notes, and private notes, view the log on Madeline:
+<%= t('notification_mailer.view_on_site.plain_text') %>
 
 Logs: <%= admin_loan_url(@log.project) %>/logs
 

--- a/app/views/notification_mailer/new_log.text.erb
+++ b/app/views/notification_mailer/new_log.text.erb
@@ -6,10 +6,10 @@
 
 <%= t :summary %>: <%= @log.summary %>
 
-<%= t('notification_mailer.new_log.view_on_site.plain_text') %>
+<%= t('notification_mailer.new_log.view_on_site.plain_text') %>:
 
-<%= t('notification_mailer.new_log.logs') %> <%= admin_loan_url(@log.project) %>/logs
+<%= t('notification_mailer.new_log.logs') %>: <%= admin_loan_url(@log.project) %>/logs
 
-<%= t('notification_mailer.new_log.timeline') %> <%= admin_loan_url(@log.project) %>/timeline
+<%= t('notification_mailer.new_log.timeline') %>: <%= admin_loan_url(@log.project) %>/timeline
 
 <%= t('notification_mailer.new_log.contact') %>

--- a/app/views/notification_mailer/new_log.text.erb
+++ b/app/views/notification_mailer/new_log.text.erb
@@ -6,7 +6,7 @@
 
 <%= t :summary %>: <%= @log.summary %>
 
-To view the log details, additional notes, and private notes, view the log on Madeline:
+To view the log's details, additional notes, and private notes, view the log on Madeline:
 
 Logs: <%= admin_loan_url(@log.project) %>/logs
 

--- a/config/locales/en/notification_mailer.en.yml
+++ b/config/locales/en/notification_mailer.en.yml
@@ -1,6 +1,11 @@
 en:
   notification_mailer:
     new_log:
-      subject: "[Madeline] New log on %{project}"
-      created: "A new log has been created on %{project} by %{agent}"
       contact: "Reply to this email to contact the author of the log."
+      created: "A new log has been created on %{project} by %{agent}"
+      logs: "Logs:"
+      subject: "[Madeline] New log on %{project}"
+      timeline: "Timeline:"
+      view_on_site:
+        html: "View the log on Madeline:"
+        plain_text: "To view the log's details, additional notes, and private notes, view the log on Madeline:"

--- a/config/locales/en/notification_mailer.en.yml
+++ b/config/locales/en/notification_mailer.en.yml
@@ -3,9 +3,9 @@ en:
     new_log:
       contact: "Reply to this email to contact the author of the log."
       created: "A new log has been created on %{project} by %{agent}"
-      logs: "Logs:"
+      logs: "Logs"
       subject: "[Madeline] New log on %{project}"
-      timeline: "Timeline:"
+      timeline: "Timeline"
       view_on_site:
-        html: "View the log on Madeline:"
-        plain_text: "To view the log's details, additional notes, and private notes, view the log on Madeline:"
+        html: "View the log on Madeline"
+        plain_text: "To view the log's details, additional notes, and private notes, view the log on Madeline"


### PR DESCRIPTION
- Ensure log emails have both plain text and html/rich text templates
- Fixes bug where raw HTML was showing in emails being sent