### PR TITLE
9876: update documentations behavior such that a user may see documen…

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -72,7 +72,7 @@ module AdminHelper
     placement = options[:placement] || 'right'
     if documentation.present?
       data_content = documentation&.summary_content.to_s
-      if documentation.page_content.present?
+      if documentation.page_content.present? && policy(documentation).show?
         learn_more_link = link_to t("documentation.learn_more"), admin_documentation_path(documentation), target: :_blank
         data_content << "<br /><br />" << learn_more_link
       end

--- a/app/policies/documentation_policy.rb
+++ b/app/policies/documentation_policy.rb
@@ -1,6 +1,12 @@
 class DocumentationPolicy < ApplicationPolicy
   def show?
-    # show if any of the user's divisions match the record's division or any of its ancestors
+    # a user may see documentations that belong to any of their divisions or any ancestors of their division
+    user_divisions = user.accessible_division_ids + user.division.self_and_ancestor_ids
+    user_divisions.include?(record.division.id)
+  end
+
+  def update?
+    # allow edit if any of the user's divisions match the record's division or any of its ancestors
     user_divisions = user.accessible_division_ids
     record_divisions = record&.division&.self_and_ancestor_ids
     intersection = (user_divisions & record_divisions)

--- a/app/policies/documentation_policy.rb
+++ b/app/policies/documentation_policy.rb
@@ -1,15 +1,6 @@
 class DocumentationPolicy < ApplicationPolicy
   def show?
-    # a user may see documentations that belong to any of their divisions or any ancestors of their division
-    user_divisions = user.accessible_division_ids + user.division.self_and_ancestor_ids
-    user_divisions.include?(record.division.id)
-  end
-
-  def update?
-    # allow edit if any of the user's divisions match the record's division or any of its ancestors
-    user_divisions = user.accessible_division_ids
-    record_divisions = record&.division&.self_and_ancestor_ids
-    intersection = (user_divisions & record_divisions)
-    intersection.present?
+    user.division.self_and_ancestors.include?(record.division) ||
+      record.division.ancestors.include?(user.division)
   end
 end

--- a/spec/policies/documentation_policy_spec.rb
+++ b/spec/policies/documentation_policy_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe DocumentationPolicy do
+  subject { described_class.new(user, record) }
+
+  let!(:parent_division) { create(:division) }
+  let!(:division) { create(:division, parent: parent_division) }
+  let!(:child_division) { create(:division, parent: division) }
+  let(:user) { create(:user, :member, division: division) }
+
+  context "documentation belongs to user's division" do
+    let(:record) { create(:documentation, division: division) }
+
+    it { should permit_all }
+  end
+
+  context "documentation belongs to ancestor of user's division" do
+    let(:record) { create(:documentation, division: parent_division) }
+
+    it { should permit_action(:show) }
+    it { should forbid_action(:edit) }
+  end
+
+  context "documentation belongs to descendant of user's division" do
+    let(:record) { create(:documentation, division: child_division) }
+
+    it { should permit_action(:show) }
+    it { should permit_action(:edit) }
+  end
+
+  context "documentation belongs to a division that is not a descendant or ancestor of any of the user's divisions " do
+    let(:other_division) { create(:division) }
+    let(:record) { create(:documentation, division: other_division) }
+    it { should forbid_action(:show) }
+    it { should forbid_action(:edit) }
+  end
+end


### PR DESCRIPTION
…tations that belong to their division or any of its descendents or ancestors but may only edit a documentation if any of the user's divisions match the its division or any of its ancestors

This is a bit tedious to test. The desired behavior is:
A documentation popover is displayed if it belongs to the current division or one of its ancestors (this matches previous behavior). 
A user may VIEW a documentation that belongs to any division that is accessible to them or an ancestor of their division (this is a change from before, see Redmine issue). 
A user may EDIT only documentation that belongs to a division where it or one of its ancestors is either the user's base division or one of its descendents (this is a change from before, see Redmine issue). 
A user will see 'Learn more' link only for documentations they can view (this is a change from before, see Redmine issue).

I manually tested this with root division, financial coop (parent is root), and BRED (parent is financial coop), Buen Vivir, and CIELO (parent is Buen Vivir) on my local, for the 'no' scenarios here:
<img width="821" alt="Screen Shot 2019-08-08 at 2 29 20 PM" src="https://user-images.githubusercontent.com/4730344/62728198-258c9700-b9e9-11e9-9ea6-e0d8d533bf45.png">
