### PR TITLE
10208 fix status and activity messages

### DIFF
--- a/app/jobs/data_export_task_job.rb
+++ b/app/jobs/data_export_task_job.rb
@@ -2,11 +2,13 @@ class DataExportTaskJob < TaskJob
   def perform(job_params)
     data_export = DataExport.find(job_params[:data_export_id])
     begin
+      task_for_job(self).set_activity_message("in_progress")
       ::DataExportService.run(data_export)
     rescue DataExportError => e
       task_for_job(self).update(custom_error_data: e.child_errors)
       task_for_job(self).set_activity_message("finished_with_custom_error_data")
       raise e
     end
+    task_for_job(self).set_activity_message("completed")
   end
 end

--- a/app/jobs/full_fetcher_job.rb
+++ b/app/jobs/full_fetcher_job.rb
@@ -4,5 +4,6 @@ class FullFetcherJob < TaskJob
   def perform(job_params)
     division = Division.find(job_params[:division_id])
     Accounting::Quickbooks::FullFetcher.new(division).fetch_all
+    task_for_job(self).set_activity_message("completed")
   end
 end

--- a/app/jobs/update_all_loans_job.rb
+++ b/app/jobs/update_all_loans_job.rb
@@ -15,8 +15,7 @@ class UpdateAllLoansJob < TaskJob
         next
       end
     end
-    task.update(custom_error_data: errors_by_loan)
-    task.set_activity_message("finished_with_custom_error_data")
+    handle_child_errors(task, errors_by_loan)
   end
 
   rescue_from(Accounting::Quickbooks::NotConnectedError) do |error|
@@ -34,7 +33,19 @@ class UpdateAllLoansJob < TaskJob
     record_failure_and_raise_error(error)
   end
 
+  rescue_from(TaskHasChildErrorsError) do |error|
+    task_for_job(self).set_activity_message("finished_with_custom_error_data")
+    record_failure_and_raise_error(error)
+  end
+
   private
+
+  def handle_child_errors(task, errors_by_loan)
+    unless errors_by_loan.empty?
+      task.update(custom_error_data: errors_by_loan)
+      raise TaskHasChildErrorsError.new("Some loans failed to update.")
+    end
+  end
 
   def record_failure_and_raise_error(error)
     task_for_job(self).fail!

--- a/app/models/task_has_child_errors_error.rb
+++ b/app/models/task_has_child_errors_error.rb
@@ -1,0 +1,2 @@
+class TaskHasChildErrorsError < StandardError
+end

--- a/config/locales/en/task.en.yml
+++ b/config/locales/en/task.en.yml
@@ -1,12 +1,14 @@
 en:
   task:
     activity_message:
+      completed: "Complete"
       error_data_reset_required: "Error: Quickbooks data reset required"
       error_quickbooks_not_connected: "Error: Quickbooks not connected"
       error_quickbooks_accounts_not_selected: "Error: QuickBooks accounts not set. Select QuickBooks accounts on the Accounting Settings page."
       failed: "Task failed with an internal error. An administrator has been notified."
       fetching_quickbooks_data: "Fetching Quickbooks Data"
       finished_with_custom_error_data: "This task completed with errors. See error details."
+      in_progress: "In progress"
       syncing_with_quickbooks: "Syncing with Quickbooks"
       task_enqueued: "This task has been enqueued"
       updating_all_loans: "Updating %{total} loans. %{so_far} loans updated so far."

--- a/spec/jobs/data_export_task_job_spec.rb
+++ b/spec/jobs/data_export_task_job_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe DataExportTaskJob do
+  let(:task) { create(:task, job_class: DataExportTaskJob) }
+  let(:data_export) { create(:data_export) }
+
+  context "has errors on some loans" do
+    it "should fail and have relevant activity message" do
+      allow(::DataExportService).to receive(:run).and_raise DataExportError
+      expect { DataExportTaskJob.perform_now(task_id: task.id, data_export_id: data_export.id) }.to raise_error DataExportError
+      expect(task.reload.status).to eq :failed
+      expect(task.reload.activity_message_value).to eq "finished_with_custom_error_data"
+    end
+  end
+
+  context "no errors" do
+    it "should succeed and have appropriate activity message" do
+      allow(::DataExportService).to receive(:run).and_return(0)
+      DataExportTaskJob.perform_now(task_id: task.id, data_export_id: data_export.id)
+      expect(task.reload.status).to eq :succeeded
+      expect(task.reload.activity_message_value).to eq "completed"
+    end
+  end
+end

--- a/spec/jobs/update_all_loans_job_spec.rb
+++ b/spec/jobs/update_all_loans_job_spec.rb
@@ -3,6 +3,23 @@ require "rails_helper"
 describe UpdateAllLoansJob do
   let(:task) { create(:task, job_class: UpdateAllLoansJob) }
 
+  context "not all loans succeeded" do
+    subject(:update_all_loans_job) do
+      Class.new(described_class) do
+        def perform(_task_data, *_args)
+          task = task_for_job(self)
+          handle_child_errors(task, [{"1": "test"}])
+        end
+      end
+    end
+
+    it "should fail and have relevant activity message" do
+      expect { subject.perform_now(task_id: task.id) }.to raise_error TaskHasChildErrorsError
+      expect(task.reload.status).to eq :failed
+      expect(task.reload.activity_message_value).to eq "finished_with_custom_error_data"
+    end
+  end
+
   context "qb is not connected" do
 
     subject(:task_job) do


### PR DESCRIPTION
This PR covers the following corrections:

1) Before this PR, the quickbooks import task showed activity message "Fetching Quickbooks data " even after it succeeded. Now it's activity message is "completed" if the task succeeds. 

2) Before this PR, the data export task still showed its activity message as "This task has been enqueued" after it had succeeded. Now its activity message is "complete" if the task succeeds. 

3) UpdateAllLoansTask was showing its status as "succeeded" when it had child errors for individual loans. Now it shows its status as "Failed" in this case. 
