### PR TITLE
10321: Visually display a new table inside a group

### DIFF
--- a/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
@@ -38,6 +38,8 @@ div
           - header_tag = {tag: %i(h3 h4 h5)[question.depth] || :h5}
           *header_tag
             = question.full_number_and_label
+          // If a group, stop grouping number items into a table.
+          - @previous_number_table = false
         - else
           // For numerical questions in print view, the question's label is displayed with
           // the question's answer.


### PR DESCRIPTION
This fixes a bug where the first number item inside a group was missing a top border inside the number table.

A group begins a new grouping for number questions. These items are displayed as their own combined table.