### PR TITLE
10348 bugfix number tables inside loan memo summary groups

### DIFF
--- a/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
@@ -38,7 +38,7 @@ div
           - header_tag = {tag: %i(h3 h4 h5)[question.depth] || :h5}
           *header_tag
             = question.full_number_and_label
-          // If a group, stop grouping number items into a table.
+          // If a group, stop grouping number items into previous table.
           - @previous_number_table = false
         - else
           // For numerical questions in print view, the question's label is displayed with

--- a/app/views/admin/loans/questionnaires/_summary_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_summary_group.html.slim
@@ -6,7 +6,7 @@
   - css_class += ' hidden-print' if response.blank? || response.not_applicable?
   - css_class += " #{question.status}"
 
-  .question data-level=question.depth data-type=question.data_type data-id=question.id class=css_class
+  .question data-type=question.data_type data-id=question.id class=css_class
     span.tree-view
       - if question.display_in_summary == true
         - if question.data_type == 'group'

--- a/app/views/admin/loans/questionnaires/_summary_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_summary_group.html.slim
@@ -13,6 +13,8 @@
           - header_tag = {tag: :h5}
           *header_tag
             = question.full_number_and_label
+          / If a group, stop grouping number items into previous table.
+          - @previous_number_table = false
         - else
           // For numerical questions in print view, the question's label is displayed with
           // the question's answer.

--- a/app/views/admin/loans/questionnaires/_summary_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_summary_group.html.slim
@@ -5,8 +5,9 @@
   / Don't print unanswered questions or groups
   - css_class += ' hidden-print' if response.blank? || response.not_applicable?
   - css_class += " #{question.status}"
+  - display_question = question.display_in_summary == true
 
-  - if question.display_in_summary == true
+  - if display_question
     .question data-type=question.data_type data-id=question.id class=css_class
       span.tree-view
         - if question.data_type == 'group'
@@ -24,8 +25,7 @@
   - if question.group? && !question.leaf?
     = render("admin/loans/questionnaires/summary_group", f: f,
       response_set: response_set, group: question, parents: parents + [question])
-  - elsif question.display_in_summary == true
+  - elsif display_question
     .answer-wrapper.tree-view
       = render("admin/loans/questionnaires/answer", f: f, response: response, question: question)
-
-  = render("admin/loans/questionnaires/summary_number_handling", response: response)
+    = render("admin/loans/questionnaires/summary_number_handling", response: response)

--- a/app/views/admin/loans/questionnaires/_summary_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_summary_group.html.slim
@@ -25,9 +25,9 @@
     - if question.group? && !question.leaf?
       = render("admin/loans/questionnaires/summary_group", f: f,
         response_set: response_set, group: question, parents: parents + [question])
-
     - elsif question.display_in_summary == true
       .answer-wrapper.tree-view
         = render("admin/loans/questionnaires/answer", f: f, response: response, question: question)
-
-  = render("admin/loans/questionnaires/number_handling", response: response)
+      - @previous_number_table = true
+    - else
+      - @previous_number_table = false

--- a/app/views/admin/loans/questionnaires/_summary_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_summary_group.html.slim
@@ -6,9 +6,9 @@
   - css_class += ' hidden-print' if response.blank? || response.not_applicable?
   - css_class += " #{question.status}"
 
-  .question data-type=question.data_type data-id=question.id class=css_class
-    span.tree-view
-      - if question.display_in_summary == true
+  - if question.display_in_summary == true
+    .question data-type=question.data_type data-id=question.id class=css_class
+      span.tree-view
         - if question.data_type == 'group'
           - header_tag = {tag: :h5}
           *header_tag
@@ -16,18 +16,16 @@
           / If a group, stop grouping number items into previous table.
           - @previous_number_table = false
         - else
-          // For numerical questions in print view, the question's label is displayed with
-          // the question's answer.
+          // For numerical questions, the question's label is displayed with the question's answer.
           .question-label class=(response.has_number? ? 'hidden-print' : '')
             = question.full_number_and_label
 
-    / Recurse if group, else render
-    - if question.group? && !question.leaf?
-      = render("admin/loans/questionnaires/summary_group", f: f,
-        response_set: response_set, group: question, parents: parents + [question])
-    - elsif question.display_in_summary == true
-      .answer-wrapper.tree-view
-        = render("admin/loans/questionnaires/answer", f: f, response: response, question: question)
-      - @previous_number_table = true
-    - else
-      - @previous_number_table = false
+  / Recurse if group, else render
+  - if question.group? && !question.leaf?
+    = render("admin/loans/questionnaires/summary_group", f: f,
+      response_set: response_set, group: question, parents: parents + [question])
+  - elsif question.display_in_summary == true
+    .answer-wrapper.tree-view
+      = render("admin/loans/questionnaires/answer", f: f, response: response, question: question)
+
+  = render("admin/loans/questionnaires/summary_number_handling", response: response)

--- a/app/views/admin/loans/questionnaires/_summary_number_handling.html.slim
+++ b/app/views/admin/loans/questionnaires/_summary_number_handling.html.slim
@@ -1,0 +1,12 @@
+- if response.has_number?
+  - if response.number.present? && !response.not_applicable?
+    - @previous_number_table = true
+  - else
+    / Empty and not applicable responses do not show
+    / If a number table was displayed before the current response, keep track of previous table
+    - if @previous_number_table
+      - @previous_number_table = true
+    - else
+      - @previous_number_table = false
+- else
+  - @previous_number_table = false


### PR DESCRIPTION
- Show top border for first number question inside a displayed group
- Remove staggered content inside summary and keep all content at same horizontal level
- Group number questions where possible