### PR TITLE
10481 plt index by loan

### DIFF
--- a/app/controllers/admin/accounting/problem_loan_transactions_controller.rb
+++ b/app/controllers/admin/accounting/problem_loan_transactions_controller.rb
@@ -4,10 +4,11 @@ module Admin
       def index
         authorize :'accounting/problem_loan_transaction', :index?
         if params[:loan_id]
-          txn_ids = ::Accounting::ProblemLoanTransaction.where(project_id: params[:loan_id]).map(&:accounting_transaction_id)
+          @loan_id = params[:loan_id]
+          txn_ids = ::Accounting::ProblemLoanTransaction.where(project_id: @loan_id).map(&:accounting_transaction_id)
           @plts = ::Accounting::ProblemLoanTransaction.where(accounting_transaction_id: txn_ids).group_by(&:txn_id)
         else
-          @plts = ::Accounting::ProblemLoanTransaction.all.group_by(&:project_id)
+          @plts = ::Accounting::ProblemLoanTransaction.all.sort_by(&:project_id).group_by(&:project_id)
           render :index_by_loan
         end
       end

--- a/app/controllers/admin/accounting/problem_loan_transactions_controller.rb
+++ b/app/controllers/admin/accounting/problem_loan_transactions_controller.rb
@@ -7,7 +7,8 @@ module Admin
           txn_ids = ::Accounting::ProblemLoanTransaction.where(project_id: params[:loan_id]).map(&:accounting_transaction_id)
           @plts = ::Accounting::ProblemLoanTransaction.where(accounting_transaction_id: txn_ids).group_by(&:txn_id)
         else
-          @plts = ::Accounting::ProblemLoanTransaction.all.group_by(&:txn_id)
+          @plts = ::Accounting::ProblemLoanTransaction.all.group_by(&:project_id)
+          render :index_by_loan
         end
       end
 

--- a/app/views/admin/accounting/problem_loan_transactions/index.html.slim
+++ b/app/views/admin/accounting/problem_loan_transactions/index.html.slim
@@ -1,4 +1,4 @@
-- content_for(:title, t("problem_loan_transaction.index.title"))
+- content_for(:title, t("problem_loan_transaction.index.title", loan_id: @loan_id))
 
 table.table.table-bordered.middle-aligned
   thead
@@ -8,8 +8,8 @@ table.table.table-bordered.middle-aligned
       th= t("problem_loan_transaction.qb_id")
       th= t("problem_loan_transaction.date")
       th= t("problem_loan_transaction.loan_id")
-      th= t("problem_loan_transaction.message")
-      th= t("problem_loan_transaction.level")
+      th= t("problem_loan_transaction.message.header")
+      th= t("problem_loan_transaction.level.header")
 
   tbody
     - @plts.each do |txn_id, plts|

--- a/app/views/admin/accounting/problem_loan_transactions/index_by_loan.html.slim
+++ b/app/views/admin/accounting/problem_loan_transactions/index_by_loan.html.slim
@@ -4,8 +4,8 @@ table.table.table-bordered.middle-aligned
   thead
     tr
       th= t("problem_loan_transaction.loan_id")
-      th= t("problem_loan_transaction.level")
-      th= t("problem_loan_transaction.message")
+      th= t("problem_loan_transaction.message.header")
+      th= t("problem_loan_transaction.level.header")
       th= t("problem_loan_transaction.num_txns_with_message")
       th= t("problem_loan_transaction.details")
 
@@ -18,8 +18,8 @@ table.table.table-bordered.middle-aligned
         tr
           - if index == 0
             td{rowspan=num_rows}= link_to loan_id, admin_accounting_problem_loan_transactions_path(loan_id: loan_id)
-          td= txns.first.level
-          td= msg
+          td= t("problem_loan_transaction.#{msg}")
+          td= t("problem_loan_transaction.level.#{txns.first.level}")
           td = txns.count
           - if index == 0
             td{rowspan=num_rows}= link_to "Click to see all transaction errors and warnings for this loan.", admin_accounting_problem_loan_transactions_path(loan_id: loan_id)

--- a/app/views/admin/accounting/problem_loan_transactions/index_by_loan.html.slim
+++ b/app/views/admin/accounting/problem_loan_transactions/index_by_loan.html.slim
@@ -1,0 +1,25 @@
+- content_for(:title, t("problem_loan_transaction.index_by_loan.title"))
+
+table.table.table-bordered.middle-aligned
+  thead
+    tr
+      th= t("problem_loan_transaction.loan_id")
+      th= t("problem_loan_transaction.level")
+      th= t("problem_loan_transaction.message")
+      th= t("problem_loan_transaction.num_txns_with_message")
+      th= t("problem_loan_transaction.details")
+
+  tbody
+    - @plts.each do |loan_id, txns|
+      - total = txns.count
+      - txns_by_message = txns.group_by(&:message)
+      - num_rows = txns_by_message.count
+      - txns_by_message.each_with_index do |(msg, txns), index|
+        tr
+          - if index == 0
+            td{rowspan=num_rows}= link_to loan_id, admin_accounting_problem_loan_transactions_path(loan_id: loan_id)
+          td= txns.first.level
+          td= msg
+          td = txns.count
+          - if index == 0
+            td{rowspan=num_rows}= link_to "Click to see all transaction errors and warnings for this loan.", admin_accounting_problem_loan_transactions_path(loan_id: loan_id)

--- a/app/views/admin/accounting/problem_loan_transactions/index_by_loan.html.slim
+++ b/app/views/admin/accounting/problem_loan_transactions/index_by_loan.html.slim
@@ -10,16 +10,17 @@ table.table.table-bordered.middle-aligned
       th= t("problem_loan_transaction.details")
 
   tbody
-    - @plts.each do |loan_id, txns|
-      - total = txns.count
-      - txns_by_message = txns.group_by(&:message)
-      - num_rows = txns_by_message.count
-      - txns_by_message.each_with_index do |(msg, txns), index|
+    - @plts.each do |loan_id, plts_for_loan|
+      - total = plts_for_loan.count
+      - plts_by_message = plts_for_loan.group_by(&:message)
+      - num_rows = plts_by_message.count
+      - plts_by_message.each_with_index do |(msg, plts_for_message), index|
         tr
+          - sample_plt = plts_for_message.first
           - if index == 0
             td{rowspan=num_rows}= link_to loan_id, admin_accounting_problem_loan_transactions_path(loan_id: loan_id)
-          td= t("problem_loan_transaction.#{msg}")
-          td= t("problem_loan_transaction.level.#{txns.first.level}")
-          td = txns.count
+          td= t("problem_loan_transaction.#{msg}", (sample_plt.custom_data.present? ? sample_plt.custom_data.symbolize_keys : {}))
+          td= t("problem_loan_transaction.level.#{sample_plt.level}")
+          td = plts_for_message.count
           - if index == 0
             td{rowspan=num_rows}= link_to "Click to see all transaction errors and warnings for this loan.", admin_accounting_problem_loan_transactions_path(loan_id: loan_id)

--- a/config/locales/en/problem_loan_transactions.en.yml
+++ b/config/locales/en/problem_loan_transactions.en.yml
@@ -17,7 +17,7 @@ en:
       warning: Warning
     message:
       header: Message
-    num_txns_with_message: Number of Transactions with this Message for this Loan
+    num_txns_with_message: Number of Transactions with Similar Messages for this Loan
     associated_loans: Associated Loans
     quickbooks_data: Raw Quickbooks Data
     error_msg_link:

--- a/config/locales/en/problem_loan_transactions.en.yml
+++ b/config/locales/en/problem_loan_transactions.en.yml
@@ -1,7 +1,9 @@
 en:
   problem_loan_transaction:
     index:
-      title: Transactions with Errors or Warnings
+      title: "Transactions with Errors or Warnings for Loan %{loan_id}"
+    index_by_loan:
+      title: Loans with Transaction Errors or Warnings
     show:
       title: "Broken Transaction #%{id} for loans %{associated_loan_ids}"
     id: ID
@@ -9,7 +11,13 @@ en:
     qb_id: QB ID
     date: Date
     loan_id: Loan ID
-    level: Level
+    level:
+      header: Level
+      error: Error
+      warning: Warning
+    message:
+      header: Message
+    num_txns_with_message: Number of Transactions with this Message for this Loan
     associated_loans: Associated Loans
     quickbooks_data: Raw Quickbooks Data
     error_msg_link:

--- a/db/migrate/20200228160741_add_custom_data_to_problem_loan_transactions.rb
+++ b/db/migrate/20200228160741_add_custom_data_to_problem_loan_transactions.rb
@@ -1,0 +1,5 @@
+class AddCustomDataToProblemLoanTransactions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounting_problem_loan_transactions, :custom_data, :json
+  end
+end


### PR DESCRIPTION
With the introduction of closed books date warnings (10454), we used Problem Loan Transactions to record warnings about closed books dates. Because of this, we will not expect the number of problem loan txns to reach zero, and there can be a looot of warnings on one loan e.g. 27 on loan 1329 with a cbd of dec 31, 2017. TWW has asked to use the (/admin/accounting/problem_loan_transactions) view to see what loans have errors. With closed book date warnings and the format on develop, it is overwhelming and makes it looks like there are more problems than there are. This refactors the index view to show which loans have problem loan txns, and then link to the loan-specific index view of problem loan transactions for details. The goal here is to make the (/admin/accounting/problem_loan_transactions) view minimally usable to TWW staff. 

This introduces another index template. 

I do not think my changes meet accessibility standards.

Happy to have someone else take another pass at this - there might be a better way to do this with wicegrid etc. 

@meltheadorable 1) should I add specs 2) should @emitche or the both of us work on a way to share code between existing index template and the index_by_loan template introduced here? 3) should we add a link to (/admin/accounting/problem_loan_transactions) from the Accounting Settings page? 