### PR TITLE
10505: create problem loan txn entry if transaction extractor cannot …

### DIFF
--- a/app/models/accounting/interest_calculator.rb
+++ b/app/models/accounting/interest_calculator.rb
@@ -142,7 +142,7 @@ module Accounting
     delegate :qb_division, to: :loan
 
     def record_and_rollback_changes(txn)
-      ::Accounting::ProblemLoanTransaction.create(loan: loan, accounting_transaction: txn, message: :attemped_change_before_closed_books_date, custom_data: {cbd: @closed_books_date, txn_date: txn.txn_date}, level: :warning)
+      ::Accounting::ProblemLoanTransaction.create(loan: loan, accounting_transaction: txn, message: :attempted_change_before_closed_books_date, custom_data: {cbd: @closed_books_date, txn_date: txn.txn_date}, level: :warning)
       new_line_items = txn.line_items.select(&:new_record?)
       new_line_items.each { |li| txn.line_items.delete(li) }
       txn.line_items.each(&:restore_attributes)

--- a/app/models/accounting/quickbooks/transaction_extractor.rb
+++ b/app/models/accounting/quickbooks/transaction_extractor.rb
@@ -37,7 +37,11 @@ module Accounting
 
       def extract_line_items
         txn.quickbooks_data['line_items'].each do |li|
-          acct = Accounting::Account.find_by(qb_id: li[qb_li_detail_key]['account_ref']['value'])
+          begin
+            acct = Accounting::Account.find_by(qb_id: li[qb_li_detail_key]['account_ref']['value'])
+          rescue
+            ::Accounting::ProblemLoanTransaction.create(loan: @loan, accounting_transaction: txn, message: :unprocessable_account, level: :error, custom_data: {} )
+          end
           # skip if line item does not have an account in Madeline
           next unless acct
           posting_type = li[qb_li_detail_key]['posting_type']

--- a/app/models/accounting/quickbooks/transaction_extractor.rb
+++ b/app/models/accounting/quickbooks/transaction_extractor.rb
@@ -40,7 +40,7 @@ module Accounting
           begin
             acct = Accounting::Account.find_by(qb_id: li[qb_li_detail_key]['account_ref']['value'])
           rescue
-            ::Accounting::ProblemLoanTransaction.create(loan: @loan, accounting_transaction: txn, message: :unprocessable_account, level: :error, custom_data: {} )
+            ::Accounting::ProblemLoanTransaction.create(loan: @loan, accounting_transaction: txn, message: :unprocessable_account, level: :error, custom_data: {})
           end
           # skip if line item does not have an account in Madeline
           next unless acct

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -525,9 +525,10 @@ en:
     the_day: "The %{day}"
 
   problem_loan_transaction:
-    journal_entry_type_other_account_not_set: "Transaction of type Other does not have account set. Please review line items for accuracy."
+    unprocessable_account: "Transaction contains line item with unprocessable account. Please review and fix in Quickbooks."
+    journal_entry_type_other_account_not_set: "Transaction of type Other does not have account set. Please review line items in Quickbooks for accuracy."
     has_multiple_loans: "Transaction associated with multiple loans"
-    attemped_change_before_closed_books_date: "Madeline would have altered this transaction (dated %{txn_date}) if it were not before the closed books date %{cbd}. Please review books for accuracy."
+    attempted_change_before_closed_books_date: "Madeline would have altered this transaction (dated %{txn_date}) if it were not before the closed books date %{cbd}. Please review books for accuracy."
     no_end_of_month_int_txn_before_closed_books_date: "Madeline would have added an end-of-month interest transaction after this one (dated %{txn_date}) if it were not before the closed books date %{cbd}. Please review books for accuracy."
     attempted_new_int_txn_before_closed_books_date: "Madeline would have added an interest transaction on same date as this one (%{txn_date}) if it were not before the closed books date %{cbd}. Please review books for accuracy."
   project_step:


### PR DESCRIPTION
…process account in qb data

This addresses the "undefined method `[]' for nil:NilClass" errors from the transaction extractor in the line `    acct = Accounting::Account.find_by(qb_id: li[qb_li_detail_key]['account_ref']['value'])`. Spot checking loans with this error showed that all spot checked had a line item with a 0.00 amount and no other fields (including no account set). These are all manually created qb txns. Madeline should not handle those line items, and admins should fix them in qb. This PR creates a ProblemLoanTransaction entry instructing the admin to check the transaction in qb and fix it. 