### PR TITLE
10526: do not run interest calculation on active loans

### DIFF
--- a/app/models/accounting/interest_calculator.rb
+++ b/app/models/accounting/interest_calculator.rb
@@ -59,6 +59,7 @@ module Accounting
     end
 
     def recalculate
+      return unless @loan.active?
       prev_tx = nil
 
       txns_by_date = transactions.group_by(&:txn_date)

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -204,7 +204,7 @@ class Loan < Project
   end
 
   def active?
-    status_value == 'active'
+    status_value == STATUS_ACTIVE_VALUE
   end
 
   def healthy?

--- a/spec/models/accounting/interest_calculator_spec.rb
+++ b/spec/models/accounting/interest_calculator_spec.rb
@@ -290,6 +290,14 @@ describe Accounting::InterestCalculator do
         end
       end
     end
+
+    describe 'non active loan' do
+      let(:loan) { create(:loan, :completed, division: division, rate: 8.0) }
+      it 'does not update txns' do
+        recalculate_and_reload
+        expect(all_txns.map(&:needs_qb_push)).to eq [false, false, false, false, false, false, false]
+      end
+    end
   end
 
   describe 'creation of interest txns' do


### PR DESCRIPTION
This is a one-line change in the interest calculator to not run `recalculate` unless the loan is active. 

I reviewed the updater to confirm that the updater will take care of saving new QB information and updating balances for txns on non-active loans. 

I briefly tried adding a loud error to the reconciler if it is asked to update a txn whose loan is not active, but the spec situation wasn't easy to work with and it seemed not important enough to force this morning.

Things to note for the future: the `recalculate` method is where a NEW transaction created in Madeline get their line items set up. This is not ideal, and means if a user tries to create a txn on a non-active loan, it will not go to qb and fail silently. we could address this with by prohibiting transaction creation in the UI on non-active loans, refactoring madeline-prompted txn creation to be independent of the interest calculator, or raising an error in the interest calculator that will reach the user. @emitche is there a way to record this in the backlog? It's not on the critical path to accounting but don't want to lose track of it. 