### PR TITLE
10537: hide update txns button on loan index  if current division is …

### DIFF
--- a/app/views/admin/loans/index.html.slim
+++ b/app/views/admin/loans/index.html.slim
@@ -2,7 +2,7 @@
 
 - content_for :with_title
   = link_to t("loan.shared.new"), new_admin_loan_path, class: 'btn btn-default new-button'
-  - if policy(::Accounting::Transaction).update?
+  - if policy(::Accounting::Transaction).update? && current_division.quickbooks_connected?
     = link_to t("admin.loans.transactions.update_changed"), update_changed_admin_accounting_transactions_path, method: :patch, class: 'btn btn-default update'
 
 = render "loans_grid_definition"


### PR DESCRIPTION
…not connected to qb

In order to release 3.x to production before we 'turn on' accounting, we should hide this 'update transactions' button on the loans page so that TWW admins are less likely to be confused. 

I manually tested this on my local. The button shows when I am connected qb. It is gone when I disconnect. This is just the minimal change needed for right now. If we want to do more, we could visibly disable the button with a message about how qb needs to be connected to update txns. 