### PR TITLE
10536: add more details and warnings to closed book date help text.

### DIFF
--- a/app/views/admin/settings/index.html.slim
+++ b/app/views/admin/settings/index.html.slim
@@ -75,7 +75,7 @@ section.block
           = documentation_popover(@documentations_by_html,
             html_identifier: "#{form_identifier}_closed_books_date", options: popover_options)
         - help_note_type = @division.closed_books_date.present? ? "note_set" : "note_not_set"
-        p.help-block.note = t("quickbooks.closed_books_date.#{help_note_type}", current_date: @division.closed_books_date )
+        p.help-block.note = t("quickbooks.closed_books_date.#{help_note_type}", current_date: @division.closed_books_date)
 
         = f.input :closed_books_date, as: :date_picker
 

--- a/app/views/admin/settings/index.html.slim
+++ b/app/views/admin/settings/index.html.slim
@@ -74,7 +74,8 @@ section.block
           h2 = t("division.closed_books_date")
           = documentation_popover(@documentations_by_html,
             html_identifier: "#{form_identifier}_closed_books_date", options: popover_options)
-        p.help-block.note = t("quickbooks.closed_books_date.note")
+        - help_note_type = @division.closed_books_date.present? ? "note_set" : "note_not_set"
+        p.help-block.note = t("quickbooks.closed_books_date.#{help_note_type}", current_date: @division.closed_books_date )
 
         = f.input :closed_books_date, as: :date_picker
 

--- a/config/locales/en/settings.en.yml
+++ b/config/locales/en/settings.en.yml
@@ -23,4 +23,6 @@ en:
       pending: "QuickBooks data import pending."
       succeeded: "QuickBooks data import succeeded."
     closed_books_date:
-      note: "Madeline will not create transactions or modify Quickbooks transactions before the closed books date."
+      note_not_set: "Madeline will not create transactions or modify Quickbooks transactions before the closed books date. Attention: Madeline will create and modify Quickbooks transactions after the closed books date, and these actions cannot be undone."
+      note_set: "Madeline will not create transactions or modify Quickbooks transactions before the closed books date, currently set to %{current_date}.
+        Attention: Setting the closed books date to before %{current_date} will cause Madeline to create new transactions and modify transactions before %{current_date} in QuickBooks and these actions cannot be undone."


### PR DESCRIPTION
In demo w/ Brendan he requested more details in the closed books date help text, including what the current one is, and when it was set. We'd need to add database fields to handle when the cbd was set, so I didn't include that for now. This is what the new help text is when the cbd is not set: 
<img width="994" alt="Screen Shot 2020-03-16 at 4 36 59 PM" src="https://user-images.githubusercontent.com/4730344/76797715-8280d480-67a4-11ea-9b2c-e20c65d518bd.png">

and when it is:
<img width="1001" alt="Screen Shot 2020-03-16 at 4 36 00 PM" src="https://user-images.githubusercontent.com/4730344/76797719-844a9800-67a4-11ea-9488-9e8b280b36f2.png">
