### PR TITLE
10500 transaction form ux updates

### DIFF
--- a/app/assets/stylesheets/admin/_modals.scss
+++ b/app/assets/stylesheets/admin/_modals.scss
@@ -15,3 +15,11 @@
     display: inline-block;
   }
 }
+
+// Fix a bug where Select2 sets the width of autocomplete selects to its own determined width.
+// The width selected by Select2 can be variable and too narrow to display the content well.
+.modal {
+  .select2 {
+    width: 100% !important;
+  }
+}

--- a/app/assets/stylesheets/admin/forms/_forms.scss
+++ b/app/assets/stylesheets/admin/forms/_forms.scss
@@ -216,6 +216,10 @@ label.light {
       margin-left: .5em;
     }
   }
+
+  .radio {
+    padding-top: 0;
+  }
 }
 
 fieldset {

--- a/app/assets/stylesheets/admin/forms/_forms.scss
+++ b/app/assets/stylesheets/admin/forms/_forms.scss
@@ -158,8 +158,8 @@ form {
 }
 
 .select2-container {
-  width: 100% !important;
   padding: 0;
+  width: inherit;
 }
 
 .actions {

--- a/app/controllers/concerns/transaction_controllable.rb
+++ b/app/controllers/concerns/transaction_controllable.rb
@@ -23,7 +23,7 @@ module TransactionControllable
       Accounting::Transaction::AVAILABLE_LOAN_TRANSACTION_TYPES.include?(option[1].to_sym)
     end
     @accounts = Accounting::Account.asset_accounts - Division.root.accounts
-    @customers = Accounting::Customer.all
+    @customers = Accounting::Customer.all.order(:name)
   end
 
   # Runs the given block and handles any Quickbooks errors.

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -74,3 +74,13 @@
 
   .view-element = f.input :qb_record_id
     = @transaction.qb_id
+
+javascript:
+  $(function() {
+    $('#accounting_transaction_accounting_customer_id').select2({
+      dropdownParent: $('#transaction-modal')
+    });
+    $('#accounting_transaction_accounting_account_id').select2({
+      dropdownParent: $('#transaction-modal')
+    });
+  });

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -16,12 +16,11 @@
     .view-element
       - if @transaction.loan_transaction_type_value
         = @transaction.loan_transaction_type_value.capitalize
-    = f.input_field :loan_transaction_type_value, collection: @loan_transaction_types
+    = f.input_field :loan_transaction_type_value, collection: @loan_transaction_types, as: :radio_buttons
 
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)
     = f.input_field :txn_date, as: :date_picker
-
 
   .form-element
     = f.association :customer, collection: @customers

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -108,7 +108,7 @@ feature 'transaction flow', :accounting do
 
   def fill_txn_form(omit_amount: false, date: Time.zone.today)
     click_on 'Add Transaction'
-    select 'Disbursement', from: 'Type of Transaction'
+    choose 'Disbursement'
     fill_in 'Date', with: date.to_s
     fill_in 'accounting_transaction[amount]', with: '12.34' unless omit_amount
     select accounts.sample.name, from: 'Bank Account'


### PR DESCRIPTION
- Use radio buttons for type of transaction instead of selects/dropdown options
- Make selects with many options autocomplete selects
- Fix bug inside modals related to autocomplete selects