### PR TITLE
10986 import vendors for qb

### DIFF
--- a/app/models/accounting/qb/full_fetcher.rb
+++ b/app/models/accounting/qb/full_fetcher.rb
@@ -29,6 +29,7 @@ module Accounting
         ::Accounting::QB::AccountFetcher.new(division).fetch
         ::Accounting::QB::TransactionFetcher.new(division).fetch
         ::Accounting::QB::DepartmentFetcher.new(division).fetch
+        ::Accounting::QB::VendorFetcher.new(division).fetch
         qb_connection.update_attribute(:last_updated_at, started_fetch_at)
       rescue StandardError => error
         delete_qb_data
@@ -43,6 +44,7 @@ module Accounting
         ::Accounting::Account.delete_all
         ::Accounting::Customer.delete_all
         ::Accounting::QB::Department.delete_all
+        ::Accounting::QB::Vendor.delete_all
       end
 
       # Set this division's accounts to nil and return a hash of the QB ids of the removed accounts

--- a/app/models/accounting/qb/vendor.rb
+++ b/app/models/accounting/qb/vendor.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: accounting_customers
+#
+#  created_at      :datetime         not null
+#  id              :bigint(8)        not null, primary key
+#  name            :string           not null
+#  qb_id           :string           not null
+#  quickbooks_data :json
+#  updated_at      :datetime         not null
+#
+
+class Accounting::QB::Vendor < ApplicationRecord
+  QB_OBJECT_TYPE = 'Vendor'
+  def self.create_or_update_from_qb_object!(qb_object_type:, qb_object:)
+    vendor = find_or_initialize_by qb_id: qb_object.id
+    vendor.tap do |v|
+      v.update!(
+        name: qb_object.display_name,
+        quickbooks_data: qb_object.as_json
+      )
+    end
+  end
+
+  # The quickbooks-ruby gem does not implement a helper method for _id like account or class,
+  # and in qb api line items need entity, not vendor_id.
+  def reference
+    entity = ::Quickbooks::Model::Entity.new
+    entity.type = Accounting::QB::Vendor::QB_OBJECT_TYPE
+    entity_ref = ::Quickbooks::Model::BaseReference.new(self.qb_id)
+    entity.entity_ref = entity_ref
+    entity
+  end
+end

--- a/app/models/accounting/qb/vendor_fetcher.rb
+++ b/app/models/accounting/qb/vendor_fetcher.rb
@@ -1,0 +1,17 @@
+module Accounting
+  module QB
+    # Responsible for grabbing all quickbooks vendors and inserting or updating Accounting::Customer
+    class VendorFetcher < FetcherBase
+      def types
+        [Accounting::QB::Vendor::QB_OBJECT_TYPE]
+      end
+
+      def find_or_create(qb_object_type:, qb_object:)
+        Accounting::QB::Vendor.create_or_update_from_qb_object!(
+          qb_object_type: qb_object_type,
+          qb_object: qb_object
+        )
+      end
+    end
+  end
+end

--- a/app/models/accounting/qb/vendor_fetcher.rb
+++ b/app/models/accounting/qb/vendor_fetcher.rb
@@ -1,6 +1,6 @@
 module Accounting
   module QB
-    # Responsible for grabbing all quickbooks vendors and inserting or updating Accounting::Customer
+    # Responsible for grabbing all quickbooks vendors and inserting or updating Accounting::QB::Vendor
     class VendorFetcher < FetcherBase
       def types
         [Accounting::QB::Vendor::QB_OBJECT_TYPE]

--- a/db/migrate/20200827170232_create_accounting_qb_vendors.rb
+++ b/db/migrate/20200827170232_create_accounting_qb_vendors.rb
@@ -1,0 +1,10 @@
+class CreateAccountingQbVendors < ActiveRecord::Migration[5.2]
+  def change
+    create_table :accounting_qb_vendors do |t|
+      t.string :qb_id, null: false
+      t.string :name, null: false
+      t.json :quickbooks_data
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_20_154550) do
+ActiveRecord::Schema.define(version: 2020_08_27_170232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,6 +79,14 @@ ActiveRecord::Schema.define(version: 2020_08_20_154550) do
     t.json "quickbooks_data"
     t.datetime "updated_at", null: false
     t.index ["division_id"], name: "index_accounting_qb_departments_on_division_id"
+  end
+
+  create_table "accounting_qb_vendors", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.string "qb_id", null: false
+    t.json "quickbooks_data"
+    t.datetime "updated_at", null: false
   end
 
   create_table "accounting_transactions", id: :serial, force: :cascade do |t|

--- a/spec/models/accounting/qb/full_fetcher_spec.rb
+++ b/spec/models/accounting/qb/full_fetcher_spec.rb
@@ -35,6 +35,7 @@ describe Accounting::QB::FullFetcher, type: :model do
   let(:qb_transaction_service) { instance_double(Quickbooks::Service::JournalEntry, all: []) }
   let(:qb_customer_service) { instance_double(Quickbooks::Service::Customer, all: []) }
   let(:qb_department_service) { instance_double(Quickbooks::Service::Department, all: []) }
+  let(:qb_vendor_service) { instance_double(Quickbooks::Service::Vendor, all: []) }
   let(:account_fetcher) { Accounting::QB::AccountFetcher.new(division) }
   let!(:account_fetcher_class) {
     class_double(Accounting::QB::AccountFetcher,
@@ -51,11 +52,15 @@ describe Accounting::QB::FullFetcher, type: :model do
     class_double(Accounting::QB::CustomerFetcher,
       new: customer_fetcher).as_stubbed_const
   }
-  let(:department_class_finder_stub) { double("find_by": nil) }
   let(:department_fetcher) { Accounting::QB::DepartmentFetcher.new(division) }
   let!(:department_fetcher_class) {
     class_double(Accounting::QB::DepartmentFetcher,
       new: department_fetcher).as_stubbed_const
+  }
+  let(:vendor_fetcher) { Accounting::QB::VendorFetcher.new(division) }
+  let!(:vendor_fetcher_class) {
+    class_double(Accounting::QB::VendorFetcher,
+      new: vendor_fetcher).as_stubbed_const
   }
 
   subject { described_class.new(division) }
@@ -73,6 +78,8 @@ describe Accounting::QB::FullFetcher, type: :model do
       expect(customer_fetcher).to receive(:fetch).and_call_original
       expect(department_fetcher).to receive(:service).with("Department").and_return(qb_department_service)
       expect(department_fetcher).to receive(:fetch).and_call_original
+      expect(vendor_fetcher).to receive(:service).with("Vendor").and_return(qb_vendor_service)
+      expect(vendor_fetcher).to receive(:fetch).and_call_original
 
       transaction_type_count = Accounting::Transaction::QB_OBJECT_TYPES.count
       expect(transaction_fetcher).to receive(:service).exactly(transaction_type_count).times
@@ -127,6 +134,8 @@ describe Accounting::QB::FullFetcher, type: :model do
         expect(customer_fetcher).to receive(:fetch).and_call_original
         expect(department_fetcher).to receive(:service).with("Department").and_return(qb_department_service)
         expect(department_fetcher).to receive(:fetch).and_call_original
+        expect(vendor_fetcher).to receive(:service).with("Vendor").and_return(qb_department_service)
+        expect(vendor_fetcher).to receive(:fetch).and_call_original
 
         transaction_type_count = Accounting::Transaction::QB_OBJECT_TYPES.count
         expect(transaction_fetcher).to receive(:service).exactly(transaction_type_count).times

--- a/spec/models/accounting/qb/vendor_spec.rb
+++ b/spec/models/accounting/qb/vendor_spec.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: accounting_customers
+#
+#  created_at      :datetime         not null
+#  id              :bigint(8)        not null, primary key
+#  name            :string           not null
+#  qb_id           :string           not null
+#  quickbooks_data :json
+#  updated_at      :datetime         not null
+#
+
+require 'rails_helper'
+
+RSpec.describe Accounting::QB::Vendor, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This issue just imports qb vendors into a table in the full fetcher, exactly like customers. The vendor will be added to check txns in issue 10985 as the 'payee.' There is no UI in this issue. 

To test, I connected to QB and ran `Accounting::QB::Vendor.count` in the console and inspected to make sure they were populated. 

Fetcher code is very redundant now across customer, vendor, dept, and account. 