### PR TITLE
11105: always set doc number on je; otherwise QB sets to value that w…

### DIFF
--- a/app/models/accounting/qb/transaction_builder.rb
+++ b/app/models/accounting/qb/transaction_builder.rb
@@ -85,9 +85,9 @@ module Accounting
         if transaction.qb_id
           je.id = transaction.qb_id
           je.sync_token = transaction.quickbooks_data['sync_token']
-        else
-          je.doc_number = set_journal_number(transaction)
         end
+        je.doc_number = set_journal_number(transaction)
+
 
         je.private_note = transaction.private_note
         je.txn_date = transaction.txn_date if transaction.txn_date.present?


### PR DESCRIPTION
…e don't want and aren't sure where it comes from. 

I used debug logging in the reconcile method, watching interest txns that needed to be updaetd, to diagnose. Before this change, the doc number was correct in the  qb txn I retrieved from qb (by qb_id) before updating. The doc number was nil in the je returned from the builder. The doc number was then wrong (e.g. LLR3) in the updated transaction returned from QB. 

After this change, the doc number was correct (MS-Automatic) in all three cases.  I also checked the loan in QB and saw that the doc numbers on interest txns remained 'MS-Automatic" after adding disbursements that change interest txns. 

Example of interest transactions for disbursements in July and Aug that will change:
<img width="1073" alt="Screen Shot 2020-09-16 at 1 36 28 PM" src="https://user-images.githubusercontent.com/4730344/93372372-d0dd6180-f821-11ea-992c-1a6a652e2a41.png">

After adding a new disbursement in June:
<img width="1021" alt="Screen Shot 2020-09-16 at 1 37 19 PM" src="https://user-images.githubusercontent.com/4730344/93372410-de92e700-f821-11ea-9191-2257b333bd61.png">


