### PR TITLE
11042 check client side

### DIFF
--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -45,13 +45,14 @@ class MS.Views.TransactionModalView extends Backbone.View
     console.log("Updating disb field visibility")
     console.log(e.target.value)
     if e.target.value == "disbursement"
-      @$('.accounting_transaction_qb_object_subtype').show()
+      #@$('.accounting_transaction_qb_object_subtype').show()
+      @$('.disbursement-only').show()
       console.log("show subtype")
     else
-      @$('.accounting_transaction_qb_object_subtype').hide()
+      @$('.disbursement-only').hide()
+      #@$('.accounting_transaction_qb_object_subtype').hide()
       console.log("hide subtype")
-      @$('.accounting_transaction_qb_vendor').hide()
-      @$('.accounting_transaction_check_number').hide()
+  
       console.log("hide vendor")
       console.log("hide check number")
 
@@ -59,11 +60,13 @@ class MS.Views.TransactionModalView extends Backbone.View
     console.log("Updating check field visibility")
     console.log(e.target.value)
     if e.target.value == "Check"
+      @$('.check-only').show()
       console.log("show check number")
-      @$('.accounting_transaction_check_number').show()
+    #  @$('.accounting_transaction_check_number').show()
     else
+      @$('.check-only').hide()
       console.log("hide check_number")
-      @$('.accounting_transaction_check_number').hide()
+    #  @$('.accounting_transaction_check_number').hide()
 
 
   setDescription: (e) ->

--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -44,32 +44,17 @@ class MS.Views.TransactionModalView extends Backbone.View
       @$('.modal-content').html(data.responseText)
 
   updateDisbursementFieldVisibility: (e) ->
-    console.log("Updating disb field visibility")
-    console.log(e.target.value)
     if e.target.value == "disbursement"
-      #@$('.accounting_transaction_qb_object_subtype').show()
       @$('.disbursement-only').show()
-      console.log("show subtype")
     else
       @$('.disbursement-only').hide()
-      #@$('.accounting_transaction_qb_object_subtype').hide()
-      console.log("hide subtype")
-
-      console.log("hide vendor")
-      console.log("hide check number")
+      @$('.check-only').hide()
 
   updateCheckFieldVisibility: (e) ->
-    console.log("Updating check field visibility")
-    console.log(e.target.value)
     if e.target.value == "Check"
       @$('.check-only').show()
-      console.log("show check number")
-    #  @$('.accounting_transaction_check_number').show()
     else
       @$('.check-only').hide()
-      console.log("hide check_number")
-    #  @$('.accounting_transaction_check_number').hide()
-
 
   setDescription: (e) ->
     if e.target.value != ''

--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -8,7 +8,6 @@ class MS.Views.TransactionModalView extends Backbone.View
     'change .accounting_transaction_qb_object_subtype': 'updateCheckFieldVisibility'
 
   initialize: (params) ->
-    console.log("in initialize")
     @loanId = params.loanId
     @locale = params.locale
     url = "/admin/accounting/transactions/new"

--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -43,18 +43,22 @@ class MS.Views.TransactionModalView extends Backbone.View
       MS.loadingIndicator.hide()
       @$('.modal-content').html(data.responseText)
 
+  clearCheckField: ->
+    @$('#accounting_transaction_qb_object_subtype_check').prop("checked", false)
+    @$('.check-only').hide()
+
   updateDisbursementFieldVisibility: (e) ->
     if e.target.value == "disbursement"
       @$('.disbursement-only').show()
     else
       @$('.disbursement-only').hide()
-      @$('.check-only').hide()
+      @clearCheckField()
 
   updateCheckFieldVisibility: (e) ->
     if e.target.value == "Check"
       @$('.check-only').show()
     else
-      @$('.check-only').hide()
+      @clearCheckField()
 
   setDescription: (e) ->
     if e.target.value != ''

--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -23,6 +23,8 @@ class MS.Views.TransactionModalView extends Backbone.View
     $.get url, project_id: loanId, (html) =>
       @replaceContent(html, action)
       @$el.modal('show')
+      @$('.disbursement-only').hide()
+      @$('.check-only').hide()
 
   replaceContent: (html, action) ->
     @$el.find('.modal-content').html(html)
@@ -52,7 +54,7 @@ class MS.Views.TransactionModalView extends Backbone.View
       @$('.disbursement-only').hide()
       #@$('.accounting_transaction_qb_object_subtype').hide()
       console.log("hide subtype")
-  
+
       console.log("hide vendor")
       console.log("hide check number")
 

--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -4,9 +4,11 @@ class MS.Views.TransactionModalView extends Backbone.View
   events:
     'click [data-action="submit"]': 'submitForm'
     'ajax:complete form': 'submitComplete'
-    'change #accounting_transaction_loan_transaction_type_value': 'setDescription'
+    'change .accounting_transaction_loan_transaction_type_value': 'updateDisbursementFieldVisibility'
+    'change .accounting_transaction_qb_object_subtype': 'updateCheckFieldVisibility'
 
   initialize: (params) ->
+    console.log("in initialize")
     @loanId = params.loanId
     @locale = params.locale
     url = "/admin/accounting/transactions/new"
@@ -38,6 +40,31 @@ class MS.Views.TransactionModalView extends Backbone.View
     else
       MS.loadingIndicator.hide()
       @$('.modal-content').html(data.responseText)
+
+  updateDisbursementFieldVisibility: (e) ->
+    console.log("Updating disb field visibility")
+    console.log(e.target.value)
+    if e.target.value == "disbursement"
+      @$('.accounting_transaction_qb_object_subtype').show()
+      console.log("show subtype")
+    else
+      @$('.accounting_transaction_qb_object_subtype').hide()
+      console.log("hide subtype")
+      @$('.accounting_transaction_qb_vendor').hide()
+      @$('.accounting_transaction_check_number').hide()
+      console.log("hide vendor")
+      console.log("hide check number")
+
+  updateCheckFieldVisibility: (e) ->
+    console.log("Updating check field visibility")
+    console.log(e.target.value)
+    if e.target.value == "Check"
+      console.log("show check number")
+      @$('.accounting_transaction_check_number').show()
+    else
+      console.log("hide check_number")
+      @$('.accounting_transaction_check_number').hide()
+
 
   setDescription: (e) ->
     if e.target.value != ''

--- a/app/controllers/admin/accounting/transactions_controller.rb
+++ b/app/controllers/admin/accounting/transactions_controller.rb
@@ -79,7 +79,7 @@ class Admin::Accounting::TransactionsController < Admin::AdminController
 
   def transaction_params
     params.require(:accounting_transaction).permit(:project_id, :account_id, :amount,
-      :private_note, :accounting_account_id, :description, :txn_date, :loan_transaction_type_value, :accounting_customer_id)
+      :private_note, :accounting_account_id, :description, :txn_date, :loan_transaction_type_value, :accounting_customer_id, :qb_vendor_id, :qb_object_subtype, :check_number)
   end
 
   def render_modal_partial(status: 200)

--- a/app/controllers/concerns/transaction_controllable.rb
+++ b/app/controllers/concerns/transaction_controllable.rb
@@ -24,6 +24,7 @@ module TransactionControllable
     @loan_transaction_types = Accounting::Transaction.loan_transaction_type_options.select do |option|
       Accounting::Transaction::AVAILABLE_LOAN_TRANSACTION_TYPES.include?(option[1].to_sym)
     end
+    @qb_subtypes = [["Check", "Check"], ["None", nil]]
     @accounts = Accounting::Account.asset_accounts - Division.root.accounts
     @customers = Accounting::Customer.all.order(:name)
     @vendors = Accounting::QB::Vendor.all.order(:name)

--- a/app/controllers/concerns/transaction_controllable.rb
+++ b/app/controllers/concerns/transaction_controllable.rb
@@ -26,6 +26,7 @@ module TransactionControllable
     end
     @accounts = Accounting::Account.asset_accounts - Division.root.accounts
     @customers = Accounting::Customer.all.order(:name)
+    @vendors = Accounting::QB::Vendor.all.order(:name)
   end
 
   # Runs the given block and handles any Quickbooks errors.

--- a/app/models/accounting/qb/transaction_builder.rb
+++ b/app/models/accounting/qb/transaction_builder.rb
@@ -28,7 +28,6 @@ module Accounting
       # Creates a Purchase of type check for QB based on disbursement txn object in Madeline.
       # A check in QB has one line item whereas a disbursement txn has two LIs in Madeline.
       def build_check_for_qb(transaction)
-        raise StandardError, I18n.t('quickbooks.principal_account_incompatible_with_checks') unless @principal_account.qb_account_classification == "Expenses"
         p = ::Quickbooks::Model::Purchase.new
 
         # If transaction already exists in QB, these are required

--- a/app/models/accounting/qb/transaction_reconciler.rb
+++ b/app/models/accounting/qb/transaction_reconciler.rb
@@ -10,20 +10,28 @@ module Accounting
 
       # Creates or updates a transaction in QB based on a Transaction object created in Madeline.
       def reconcile(transaction)
+        Rails::Debug.logger.ap("RECONCILING . . . ")
+        Rails::Debug.logger.ap(transaction)
         return unless transaction.needs_qb_push?
+        if transaction.qb_id.present?
+          current_qb_je = service(transaction).find_by(:id, transaction.qb_id).first
+          Rails::Debug.logger.ap("doc num from qb: #{current_qb_je.doc_number}")
+        end
 
-        je = builder.build_for_qb(transaction)
+        qb_txn = builder.build_for_qb(transaction)
+        Rails::Debug.logger.ap("doc num from builder: #{qb_txn.doc_number}")
 
         # If the transaction already has a qb_id then it already exists in QB, so we should update it.
         # Otherwise we create it.
         raise StandardError, "DO NOT WRITE IN READ ONLY MODE" if @qb_division.qb_read_only
-        je = transaction.qb_id ? service.update(je, sparse: true) : service.create(je)
+        qb_txn = transaction.qb_id ? service(transaction).update(qb_txn, sparse: true) : service(transaction).create(qb_txn)
+        Rails::Debug.logger.ap("doc num after qb update: #{qb_txn.doc_number}")
 
         transaction.set_qb_push_flag!(false)
 
         # It's important we store the ID and type of the QB journal entry we just created
         # so that on the next sync, a duplicate is not created.
-        transaction.associate_with_qb_obj(je)
+        transaction.associate_with_qb_obj(qb_txn)
         transaction.save!
       end
 
@@ -35,8 +43,16 @@ module Accounting
         @builder ||= TransactionBuilder.new(qb_division)
       end
 
-      def service
-        @service ||= ::Quickbooks::Service::JournalEntry.new(qb_connection.auth_details)
+      def service(m_txn)
+        m_txn.subtype?("Check") ? purchase_service : je_service
+      end
+
+      def purchase_service
+        @purchase_service ||= ::Quickbooks::Service::Purchase.new(qb_connection.auth_details)
+      end
+
+      def je_service
+        @je_service ||= ::Quickbooks::Service::JournalEntry.new(qb_connection.auth_details)
       end
     end
   end

--- a/app/models/accounting/qb/transaction_reconciler.rb
+++ b/app/models/accounting/qb/transaction_reconciler.rb
@@ -16,12 +16,7 @@ module Accounting
         # If the transaction already has a qb_id then it already exists in QB, so we should update it.
         # Otherwise we create it.
         raise StandardError, "DO NOT WRITE IN READ ONLY MODE" if @qb_division.qb_read_only
-<<<<<<< HEAD
         qb_txn = transaction.qb_id ? service(transaction).update(qb_txn, sparse: true) : service(transaction).create(qb_txn)
-=======
-
-        je = transaction.qb_id ? service.update(je, sparse: true) : service.create(je)
->>>>>>> develop
 
         transaction.set_qb_push_flag!(false)
 

--- a/app/models/accounting/qb/transaction_reconciler.rb
+++ b/app/models/accounting/qb/transaction_reconciler.rb
@@ -10,22 +10,13 @@ module Accounting
 
       # Creates or updates a transaction in QB based on a Transaction object created in Madeline.
       def reconcile(transaction)
-        Rails::Debug.logger.ap("RECONCILING . . . ")
-        Rails::Debug.logger.ap(transaction)
         return unless transaction.needs_qb_push?
-        if transaction.qb_id.present?
-          current_qb_je = service(transaction).find_by(:id, transaction.qb_id).first
-          Rails::Debug.logger.ap("doc num from qb: #{current_qb_je.doc_number}")
-        end
-
         qb_txn = builder.build_for_qb(transaction)
-        Rails::Debug.logger.ap("doc num from builder: #{qb_txn.doc_number}")
 
         # If the transaction already has a qb_id then it already exists in QB, so we should update it.
         # Otherwise we create it.
         raise StandardError, "DO NOT WRITE IN READ ONLY MODE" if @qb_division.qb_read_only
         qb_txn = transaction.qb_id ? service(transaction).update(qb_txn, sparse: true) : service(transaction).create(qb_txn)
-        Rails::Debug.logger.ap("doc num after qb update: #{qb_txn.doc_number}")
 
         transaction.set_qb_push_flag!(false)
 

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -19,6 +19,13 @@
     .form-element
       = f.input_field :loan_transaction_type_value, collection: @loan_transaction_types, as: :radio_buttons
 
+  = f.input :qb_object_subtype
+    .view-element
+      - if @transaction.qb_object_subtype
+        = @transaction.qb_object_subtype.capitalize
+    .form-element
+      = f.input_field :qb_object_subtype, collection: ["Check", "JournalEntry"], as: :radio_buttons
+
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)
     = f.input_field :txn_date, as: :date_picker
@@ -29,6 +36,13 @@
     = f.input :customer
       - if @transaction.customer
         = @transaction.customer.name
+
+  .form-element
+    = f.association :vendor, collection: @vendors
+  .view-element
+    = f.input :vendor
+      - if @transaction.vendor
+        = @transaction.vendor.name
 
   = f.input :qb_department
     .form-element
@@ -54,9 +68,14 @@
       = f.input_field :amount
       span.currency = @loan.currency.present? ? @loan.currency.try(:code) : ""
 
+
   = f.input :description
     .view-element = @transaction.description
     = f.input_field :description
+
+  = f.input :check_number
+    .view-element = @transaction.check_number
+    = f.input_field :check_number
 
   / Memo
   = f.input :private_note

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -24,7 +24,7 @@
       - if @transaction.qb_object_subtype
         = @transaction.qb_object_subtype.capitalize
     .form-element
-      = f.input_field :qb_object_subtype, collection: ["Check", "JournalEntry"], as: :radio_buttons
+      = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
 
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -19,12 +19,23 @@
     .form-element
       = f.input_field :loan_transaction_type_value, collection: @loan_transaction_types, as: :radio_buttons
 
-  = f.input :qb_object_subtype
-    .view-element
-      - if @transaction.qb_object_subtype
-        = @transaction.qb_object_subtype.capitalize
-    .form-element
-      = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+  .form-element.disbursement-only
+    = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+  .view-element
+    - if @transaction.qb_object_subtype
+      = @transaction.qb_object_subtype.capitalize
+
+  .form-element.disbursement-only
+    = f.association :vendor, collection: @vendors
+  .view-element
+    = f.input :vendor
+      - if @transaction.vendor
+        = @transaction.vendor.name
+
+  .form-element.check-only
+    = f.input :check_number
+  .view-element = @transaction.check_number
+    = f.input_field :check_number
 
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)
@@ -36,13 +47,6 @@
     = f.input :customer
       - if @transaction.customer
         = @transaction.customer.name
-
-  .form-element
-    = f.association :vendor, collection: @vendors
-  .view-element
-    = f.input :vendor
-      - if @transaction.vendor
-        = @transaction.vendor.name
 
   = f.input :qb_department
     .form-element
@@ -72,10 +76,6 @@
   = f.input :description
     .view-element = @transaction.description
     = f.input_field :description
-
-  = f.input :check_number
-    .view-element = @transaction.check_number
-    = f.input_field :check_number
 
   / Memo
   = f.input :private_note

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -231,6 +231,7 @@ en:
         amount: "Amount"
         change_in_interest: "Change in Interest"
         change_in_principal: "Change in Principal"
+        check_number: "Check Number"
         customer: "QuickBooks Customer"
         description: "Description"
         interest_balance: "Interest Balance"
@@ -238,9 +239,11 @@ en:
         principal_balance: "Principal Balance"
         private_note: "Memo"
         qb_department: "QB Division"
+        qb_object_subtype: "Subtype of Transaction"
         qb_record_id: "QuickBooks Record ID"
         total_balance: "Total Balance"
         txn_date: "Date"
+        vendor: "Vendor"
       timeline_step_move:
         move_type: "Which Date?"
     options:

--- a/spec/factories/accounting_qb_vendors_factory.rb
+++ b/spec/factories/accounting_qb_vendors_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :accounting_qb_vendor, class: 'Accounting::QB::Vendor', aliases: [:vendor] do
+    sequence(:qb_id)
+    sequence(:name) { |n| "Vendor #{n}" }
+  end
+end

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -108,8 +108,8 @@ feature 'transaction flow', :accounting do
         expect(page).to have_content('Check Number')
         fill_in 'Check Number', with: 123
         select vendors.sample.name, from: 'Vendor'
-        fill_in 'Date', with: date.to_s
-        fill_in 'accounting_transaction[amount]', with: '12.34' unless omit_amount
+        fill_in 'Date', with: Time.zone.today.to_s
+        fill_in 'accounting_transaction[amount]', with: '12.34'
         select accounts.sample.name, from: 'Bank Account'
         select customers.sample.name, from: 'QuickBooks Customer'
         fill_in 'Description', with: 'Test check'

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -24,6 +24,7 @@ feature 'transaction flow', :accounting do
     let(:acct_1) { create(:accounting_account) }
     let(:acct_2) { create(:accounting_account) }
     let!(:accounts) { [acct_1, acct_2] }
+    let!(:vendors) { create_list(:vendor, 2) }
 
     before do
       OptionSetCreator.new.create_loan_transaction_type
@@ -90,6 +91,31 @@ feature 'transaction flow', :accounting do
         expect(page).to have_content('Test QB Department')
         page.find('a[data-action="submit"]').click
         expect(page).to have_content('Palm trees')
+      end
+
+      scenario 'disbursement and check fields' do
+        visit "/admin/loans/#{loan.id}/transactions"
+        click_on 'Add Transaction'
+        expect(page).not_to have_content('Subtype')
+        expect(page).not_to have_content('Vendor')
+        expect(page).not_to have_content('Check Number')
+        choose 'Disbursement'
+        expect(page).to have_content('Subtype')
+        expect(page).to have_content('Vendor')
+        expect(page).not_to have_content('Check Number')
+        choose 'Check'
+        expect(page).to have_content('Subtype')
+        expect(page).to have_content('Check Number')
+        fill_in 'Check Number', with: 123
+        select vendors.sample.name, from: 'Vendor'
+        fill_in 'Date', with: date.to_s
+        fill_in 'accounting_transaction[amount]', with: '12.34' unless omit_amount
+        select accounts.sample.name, from: 'Bank Account'
+        select customers.sample.name, from: 'QuickBooks Customer'
+        fill_in 'Description', with: 'Test check'
+        fill_in 'Memo', with: 'Chunky monkey'
+        page.find('a[data-action="submit"]').click
+        expect(page).to have_content('Test check')
       end
 
       scenario 'with validation error' do


### PR DESCRIPTION
Allows user to create a check disbursement in the txn modal. 
Includes updates to transaction reconciler to support checks. 
This issue completes minimal functionality for creating check disbursements in madeline. Another issue will update UX. 


Showing disbursement fields upon choosing disbursement:
![Screen Shot 2020-09-23 at 11 42 17 AM](https://user-images.githubusercontent.com/4730344/94054557-caaf2e00-fda9-11ea-840f-56804b9e9f77.png)

Showing check number field upon choosing 'check'
![Screen Shot 2020-09-23 at 11 42 02 AM](https://user-images.githubusercontent.com/4730344/94054564-ce42b500-fda9-11ea-8190-5d274fc8a8bf.png)

Mix of non-check disbursement, check disbursements, and repayments made with this in sandbox:

![Screen Shot 2020-09-23 at 11 45 30 AM](https://user-images.githubusercontent.com/4730344/94054452-afdcb980-fda9-11ea-89b7-2bdbc6e9b85b.png)

