### PR TITLE
11136 edit txn qa fixes

### DIFF
--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -22,8 +22,9 @@ class MS.Views.TransactionModalView extends Backbone.View
     $.get url, project_id: loanId, (html) =>
       @replaceContent(html, action)
       @$el.modal('show')
-      @$('.disbursement-only').hide()
-      @$('.check-only').hide()
+      if action == "new"
+        @$('.disbursement-only').hide()
+        @$('.check-only').hide()
 
   replaceContent: (html, action) ->
     @$el.find('.modal-content').html(html)

--- a/app/assets/stylesheets/admin/forms/_transaction_form.scss
+++ b/app/assets/stylesheets/admin/forms/_transaction_form.scss
@@ -5,6 +5,11 @@
     }
   }
 
+  .principal-form-field {
+    border-bottom: 1px solid $gray2;
+    padding-bottom: 10px;
+  }
+
   .transaction-amount {
     input {
       width: 10em;

--- a/app/models/accounting/interest_calculator.rb
+++ b/app/models/accounting/interest_calculator.rb
@@ -123,7 +123,6 @@ module Accounting
             # even if we don't change anything here.
             tx.needs_qb_push = tx.needs_qb_push || tx.line_items.any?(&:type_or_amt_changed?)
 
-
             # This should save the transaction and all its line items.
             tx.save!
 

--- a/app/models/accounting/qb/transaction_builder.rb
+++ b/app/models/accounting/qb/transaction_builder.rb
@@ -33,7 +33,7 @@ module Accounting
         # If transaction already exists in QB, these are required
         if transaction.qb_id
           p.id = transaction.qb_id
-          p.sync_token = transaction.quickbooks_data['sync_token']
+          p.sync_token = transaction.sync_token
         else
           p.doc_number = set_journal_number(transaction)
         end

--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -83,7 +83,7 @@ module Accounting
           extract_qb_data(txn)
           Rails::Debug.logger.ap("calc bal in update_ledger for #{txn.loan_transaction_type_value} txn #{txn.id} on #{txn.txn_date} with total bal #{txn.reload.total_balance}")
           #Rails::Debug.logger.ap(loan.transactions.reload.standard_order.pluck(:id, :loan_transaction_type_value, :txn_date, :amount))
-          txn.reload.calculate_balances(prev_tx: prev_tx) if txn.line_items.present?
+          txn.reload.calculate_balances(prev_tx: prev_tx)
           txn.save!
           prev_tx = txn
         end

--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -78,9 +78,12 @@ module Accounting
 
       def update_ledger(loan)
         prev_tx = nil
+        Rails::Debug.logger.ap(loan.transactions.standard_order.pluck(:id, :loan_transaction_type_value, :txn_date, :amount))
         loan.transactions.standard_order.each do |txn|
           extract_qb_data(txn)
-          txn.reload.calculate_balances(prev_tx: prev_tx)
+          Rails::Debug.logger.ap("calc bal in update_ledger for #{txn.loan_transaction_type_value} txn #{txn.id} on #{txn.txn_date} with total bal #{txn.reload.total_balance}")
+          #Rails::Debug.logger.ap(loan.transactions.reload.standard_order.pluck(:id, :loan_transaction_type_value, :txn_date, :amount))
+          txn.reload.calculate_balances(prev_tx: prev_tx) if txn.line_items.present?
           txn.save!
           prev_tx = txn
         end

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -212,6 +212,10 @@ class Accounting::Transaction < ApplicationRecord
     update_column(:needs_qb_push, value)
   end
 
+  def type?(type)
+    loan_transaction_type_value == type
+  end
+
   def subtype?(subtype)
     qb_object_subtype == subtype
   end

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -181,38 +181,12 @@ class Accounting::Transaction < ApplicationRecord
   # Called from both updater and interest calculator
   # Does NOT save the object.
   def calculate_balances(prev_tx: nil)
-    if self.line_items.present?
-      # if this is a txn just created or edited in Madeline and its lis are present,
-      # then calculate_balances was called from interest calculator
-      calculate_deltas
-      self.principal_balance = (prev_tx.try(:principal_balance) || 0) + change_in_principal
-      self.interest_balance = (prev_tx.try(:interest_balance) || 0) + change_in_interest
-      if managed && total_balance < 0 && !Rails.env.test?
-        raise Accounting::QB::NegativeBalanceError.new(prev_balance: prev_balance)
-      end
-    elsif prev_tx.present?
-      # If lis are missing, then this txn is coming from madeline UI creation or edit,
-      # and calculate_balances was called from the updater.rb (since lis are extracted immediat
-      # ely from QB in  data_extractor.rb). If prev_tx is present, this is not the
-      # first transaction in the list for the loan.
-      #
-      # Deltas for this txn cannot be calculated without lis, so when calculate_balances runs
-      # from updater, balances will not be correct yet. These balances will be corrected
-      # when calculate_balances is called from the interest calculator,
-      # which creates this txn's lis.
-      # In the meantime, we need to pass prev txn's balances fwd so this txn's total balance is not zero and
-      # later repayments do not raise negative balance errors.
-      # A full remedy to this problem would involve refactoring the whole txn flow to decouple line item
-      # creation from interest calculation.
-      Rails::Debug.logger.ap("no lis; set prin bal to #{prev_tx.try(:principal_balance)}")
-      self.principal_balance = prev_tx.try(:principal_balance)
-      self.interest_balance = prev_tx.try(:interest_balance)
-    else
-      # If no line items, and no prev txn, we are creating or editing the first transaction in a loan,
-      # int calc has not run yet. In the case we are editing a txn, its balances cannot be
-      # set to 0 before its line items are created, or any repayments that may exist in the
-      # future will trigger negative balance. In the case its just created, no operation leaves
-      # the balances at zero.
+    raise StandardError, "Do not calculate balances without line items." if self.line_items.blank?
+    calculate_deltas
+    self.principal_balance = (prev_tx.try(:principal_balance) || 0) + change_in_principal
+    self.interest_balance = (prev_tx.try(:interest_balance) || 0) + change_in_interest
+    if managed && total_balance < 0 && !Rails.env.test?
+      raise Accounting::QB::NegativeBalanceError.new(prev_balance: prev_balance)
     end
   end
 
@@ -243,6 +217,7 @@ class Accounting::Transaction < ApplicationRecord
   end
 
   private
+
   # Debits minus credits for the given account. Returns a negative number if this transaction is a
   # net credit to the passed in account. Note that for non-asset accounts such as interest income,
   # which is increased by a credit, a negative number indicates the account is increasing.

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -39,12 +39,13 @@
     .form-element
       = f.input_field :vendor, collection: @vendors
 
-  .form-element.check-only
-    = f.input :check_number
-  .view-element
-    = f.input :check_number
+  = f.input :check_number, wrapper_html: {class: 'check-only'}
+    .view-element
       - if @transaction.check_number
         = @transaction.check_number
+    .form-element
+      = f.input_field :check_number
+
 
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,16 +22,16 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
-  .view-element
-    = f.input :qb_object_subtype
+  = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
+    .view-element
       - if @transaction.qb_object_subtype
         = @transaction.qb_object_subtype.capitalize
-  .form-element.disbursement-only
-    - if @transaction.new_record?
-      = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
-    - elsif @transaction.qb_object_subtype == "Check"
-      = f.input :qb_object_subtype
-        = @transaction.qb_object_subtype.capitalize
+    .form-element
+      - if @transaction.new_record?
+        = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+      - elsif @transaction.qb_object_subtype == "Check"
+        = f.input :qb_object_subtype
+          = @transaction.qb_object_subtype.capitalize
 
 
   .form-element.disbursement-only

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -30,16 +30,14 @@
       - if @transaction.new_record?
         = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
       - elsif @transaction.qb_object_subtype == "Check"
-        = f.input :qb_object_subtype
           = @transaction.qb_object_subtype.capitalize
 
-
-  .form-element.disbursement-only
-    = f.association :vendor, collection: @vendors
-  .view-element
-    = f.input :vendor
+  = f.input :vendor, wrapper_html: {class: 'disbursement-only'}
+    .view-element
       - if @transaction.vendor
         = @transaction.vendor.name
+    .form-element
+      = f.input_field :vendor, collection: @vendors
 
   .form-element.check-only
     = f.input :check_number

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,12 +22,17 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
-  .form-element.disbursement-only
-    = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
   .view-element
     = f.input :qb_object_subtype
       - if @transaction.qb_object_subtype
         = @transaction.qb_object_subtype.capitalize
+  .form-element.disbursement-only
+    - if @transaction.new_record?
+      = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+    - elsif @transaction.qb_object_subtype == "Check"
+      = f.input :qb_object_subtype
+        = @transaction.qb_object_subtype.capitalize
+
 
   .form-element.disbursement-only
     = f.association :vendor, collection: @vendors

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -12,7 +12,7 @@
 
   = f.hidden_field :project_id
 
-  = f.input :loan_transaction_type_value
+  = f.input :loan_transaction_type_value, wrapper_html: @transaction.new_record? ? {class: "principal-form-field"} : {} 
     .view-element
       - if @transaction.loan_transaction_type_value
         = @transaction.loan_transaction_type_value.capitalize

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -17,7 +17,7 @@
       - if @transaction.loan_transaction_type_value
         = @transaction.loan_transaction_type_value.capitalize
     .form-element
-      = f.input_field :loan_transaction_type_value, collection: @loan_transaction_types, as: :radio_buttons
+      = f.input_field :loan_transaction_type_value, collection: @loan_transaction_types, as: :radio_buttons, disabled: !@transaction.new_record?
 
   .form-element.disbursement-only
     = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,6 +22,9 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
+  // if new record, let js handle displaying or not.
+  // if not, only display if check because subtype null isn't meaningful to users
+  // .disbursement-only class lets js control display when new record
   - if @transaction.new_record? || @transaction.subtype?("check")
     = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
       .view-element
@@ -30,9 +33,10 @@
       .form-element
         - if @transaction.new_record?
           = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
-        - elsif @transaction.qb_object_subtype == "Check"
-            = @transaction.qb_object_subtype.capitalize
+        - else
+          = @transaction.qb_object_subtype.capitalize
 
+  // .disbursement-only class lets js control display when new record
   - if @transaction.new_record? || @transaction.type?("disbursement")
       .view-element
         - if @transaction.vendor
@@ -41,6 +45,7 @@
       .form-element
         = f.association :vendor, collection: @vendors, wrapper_html: {class: 'disbursement-only'}
 
+  // .check-only class lets js control display when new record
   - if @transaction.new_record? || @transaction.subtype?("Check")
     = f.input :check_number, wrapper_html: {class: 'check-only'}
       .view-element
@@ -48,7 +53,6 @@
           = @transaction.check_number
       .form-element
         = f.input_field :check_number
-
 
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,29 +22,32 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
-  = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
-    .view-element
-      - if @transaction.qb_object_subtype
-        = @transaction.qb_object_subtype.capitalize
-    .form-element
-      - if @transaction.new_record?
-        = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
-      - elsif @transaction.qb_object_subtype == "Check"
+  - if @transaction.new_record? || @transaction.subtype?("check")
+    = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
+      .view-element
+        - if @transaction.qb_object_subtype
           = @transaction.qb_object_subtype.capitalize
+      .form-element
+        - if @transaction.new_record?
+          = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+        - elsif @transaction.qb_object_subtype == "Check"
+            = @transaction.qb_object_subtype.capitalize
 
-  = f.input :vendor, wrapper_html: {class: 'disbursement-only'}
-    .view-element
-      - if @transaction.vendor
-        = @transaction.vendor.name
-    .form-element
-      = f.input_field :vendor, collection: @vendors
+  - if @transaction.new_record? || @transaction.type?("disbursement")
+      .view-element
+        - if @transaction.vendor
+          = f.input :vendor
+            = @transaction.vendor.name
+      .form-element
+        = f.association :vendor, collection: @vendors, wrapper_html: {class: 'disbursement-only'}
 
-  = f.input :check_number, wrapper_html: {class: 'check-only'}
-    .view-element
-      - if @transaction.check_number
-        = @transaction.check_number
-    .form-element
-      = f.input_field :check_number
+  - if @transaction.new_record? || @transaction.subtype?("Check")
+    = f.input :check_number, wrapper_html: {class: 'check-only'}
+      .view-element
+        - if @transaction.check_number
+          = @transaction.check_number
+      .form-element
+        = f.input_field :check_number
 
 
   = f.input :txn_date

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -17,7 +17,10 @@
       - if @transaction.loan_transaction_type_value
         = @transaction.loan_transaction_type_value.capitalize
     .form-element
-      = f.input_field :loan_transaction_type_value, collection: @loan_transaction_types, as: :radio_buttons, disabled: !@transaction.new_record?
+      - if @transaction.new_record?
+        = f.input_field :loan_transaction_type_value, collection: @loan_transaction_types, as: :radio_buttons
+      - else
+        = @transaction.loan_transaction_type_value.capitalize
 
   .form-element.disbursement-only
     = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -12,7 +12,7 @@
 
   = f.hidden_field :project_id
 
-  = f.input :loan_transaction_type_value, wrapper_html: @transaction.new_record? ? {class: "principal-form-field"} : {} 
+  = f.input :loan_transaction_type_value, wrapper_html: @transaction.new_record? ? {class: "principal-form-field"} : {}
     .view-element
       - if @transaction.loan_transaction_type_value
         = @transaction.loan_transaction_type_value.capitalize
@@ -25,7 +25,7 @@
   // if new record, let js handle displaying or not.
   // if not, only display if check because subtype null isn't meaningful to users
   // .disbursement-only class lets js control display when new record
-  - if @transaction.new_record? || @transaction.subtype?("check")
+  - if @transaction.new_record? || @transaction.subtype?("Check")
     = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
       .view-element
         - if @transaction.qb_object_subtype

--- a/app/views/admin/accounting/transactions/_modal_content.slim
+++ b/app/views/admin/accounting/transactions/_modal_content.slim
@@ -8,7 +8,7 @@ div.modal-header
       = @transaction.description
 
 div.modal-body
-  - unless @transaction.new_record?
+  - unless @transaction.new_record? || @transaction.type?("interest")
     .show-actions
       a.edit-action.view-element
         i.fa.fa-pencil.fa-large>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -239,7 +239,7 @@ en:
         principal_balance: "Principal Balance"
         private_note: "Memo"
         qb_department: "QB Division"
-        qb_object_subtype: "Subtype of Transaction"
+        qb_object_subtype: "Disbursement Type"
         qb_record_id: "QuickBooks Record ID"
         total_balance: "Total Balance"
         txn_date: "Date"

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -96,15 +96,15 @@ feature 'transaction flow', :accounting do
       scenario 'disbursement and check fields' do
         visit "/admin/loans/#{loan.id}/transactions"
         click_on 'Add Transaction'
-        expect(page).not_to have_content('Subtype')
+        expect(page).not_to have_content('Disbursement Type')
         expect(page).not_to have_content('Vendor')
         expect(page).not_to have_content('Check Number')
         choose 'Disbursement'
-        expect(page).to have_content('Subtype')
+        expect(page).to have_content('Disbursement Type')
         expect(page).to have_content('Vendor')
         expect(page).not_to have_content('Check Number')
         choose 'Check'
-        expect(page).to have_content('Subtype')
+        expect(page).to have_content('Disbursement Type')
         expect(page).to have_content('Check Number')
         fill_in 'Check Number', with: 123
         select vendors.sample.name, from: 'Vendor'

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -168,7 +168,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
 
     def expect_line_item_amounts(amounts)
       amounts.each_with_index do |amt, i|
-        expect(txn.line_items[i].amount).to equal_money(amt)
+        expect(txn.line_items.order(:qb_line_id)[i].amount).to equal_money(amt)
       end
     end
 

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -111,7 +111,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
       end
 
       it 'updates correctly in Madeline' do
-        expect(txn.line_items.map(&:qb_line_id)).to eq([0, 1, 2, 3, 4])
+        expect(txn.line_items.map(&:qb_line_id).sort).to eq([0, 1, 2, 3, 4])
         expect(txn.line_items.map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit', 'Credit', 'Debit'])
         expect_line_item_amounts([10.99, 1.31, 12.30, 1.00, 1.00])
 

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -111,8 +111,8 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
       end
 
       it 'updates correctly in Madeline' do
-        expect(txn.line_items.map(&:qb_line_id).sort).to eq([0, 1, 2, 3, 4])
-        expect(txn.line_items.map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit', 'Credit', 'Debit'])
+        expect(txn.line_items.order(:qb_line_id).map(&:qb_line_id)).to eq([0, 1, 2, 3, 4])
+        expect(txn.line_items.order(:qb_line_id).map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit', 'Credit', 'Debit'])
         expect_line_item_amounts([10.99, 1.31, 12.30, 1.00, 1.00])
 
         # Amount is calculated from line items so this tests all of those calculations.


### PR DESCRIPTION
Last changes needed for TWW to safely test editing non-check txns. Changes are:
- resolve negative bal errors by removing calculate_balances step from updater. Its presence there caused incorrect  math when creating or updating txns in Madeline and is a holdover from before the interest calculator was created. Now balances are calculated only in the interest calculator. 
- make the txn type field read-only when editing a txn. Screenshots below: 
<img width="788" alt="Screen Shot 2020-10-05 at 2 10 51 PM" src="https://user-images.githubusercontent.com/4730344/95134631-3772e280-0731-11eb-8154-6877b8bce549.png">
<img width="934" alt="Screen Shot 2020-10-05 at 2 10 35 PM" src="https://user-images.githubusercontent.com/4730344/95134641-393ca600-0731-11eb-823e-c04cc58bf113.png">

