### PR TITLE
11135: update check building to use sync_token field instead of quick…

### DIFF
--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -22,8 +22,9 @@ class MS.Views.TransactionModalView extends Backbone.View
     $.get url, project_id: loanId, (html) =>
       @replaceContent(html, action)
       @$el.modal('show')
-      @$('.disbursement-only').hide()
-      @$('.check-only').hide()
+      if action == "new"
+        @$('.disbursement-only').hide()
+        @$('.check-only').hide()
 
   replaceContent: (html, action) ->
     @$el.find('.modal-content').html(html)

--- a/app/assets/stylesheets/admin/forms/_transaction_form.scss
+++ b/app/assets/stylesheets/admin/forms/_transaction_form.scss
@@ -5,6 +5,11 @@
     }
   }
 
+  .principal-form-field {
+    border-bottom: 1px solid $gray2;
+    padding-bottom: 10px;
+  }
+
   .transaction-amount {
     input {
       width: 10em;

--- a/app/models/accounting/qb/transaction_builder.rb
+++ b/app/models/accounting/qb/transaction_builder.rb
@@ -33,7 +33,7 @@ module Accounting
         # If transaction already exists in QB, these are required
         if transaction.qb_id
           p.id = transaction.qb_id
-          p.sync_token = transaction.quickbooks_data['sync_token']
+          p.sync_token = transaction.sync_token
         else
           p.doc_number = set_journal_number(transaction)
         end

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -212,6 +212,10 @@ class Accounting::Transaction < ApplicationRecord
     update_column(:needs_qb_push, value)
   end
 
+  def type?(type)
+    loan_transaction_type_value == type
+  end
+
   def subtype?(subtype)
     qb_object_subtype == subtype
   end

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -39,12 +39,13 @@
     .form-element
       = f.input_field :vendor, collection: @vendors
 
-  .form-element.check-only
-    = f.input :check_number
-  .view-element
-    = f.input :check_number
+  = f.input :check_number, wrapper_html: {class: 'check-only'}
+    .view-element
       - if @transaction.check_number
         = @transaction.check_number
+    .form-element
+      = f.input_field :check_number
+
 
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,16 +22,16 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
-  .view-element
-    = f.input :qb_object_subtype
+  = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
+    .view-element
       - if @transaction.qb_object_subtype
         = @transaction.qb_object_subtype.capitalize
-  .form-element.disbursement-only
-    - if @transaction.new_record?
-      = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
-    - elsif @transaction.qb_object_subtype == "Check"
-      = f.input :qb_object_subtype
-        = @transaction.qb_object_subtype.capitalize
+    .form-element
+      - if @transaction.new_record?
+        = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+      - elsif @transaction.qb_object_subtype == "Check"
+        = f.input :qb_object_subtype
+          = @transaction.qb_object_subtype.capitalize
 
 
   .form-element.disbursement-only

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -30,16 +30,14 @@
       - if @transaction.new_record?
         = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
       - elsif @transaction.qb_object_subtype == "Check"
-        = f.input :qb_object_subtype
           = @transaction.qb_object_subtype.capitalize
 
-
-  .form-element.disbursement-only
-    = f.association :vendor, collection: @vendors
-  .view-element
-    = f.input :vendor
+  = f.input :vendor, wrapper_html: {class: 'disbursement-only'}
+    .view-element
       - if @transaction.vendor
         = @transaction.vendor.name
+    .form-element
+      = f.input_field :vendor, collection: @vendors
 
   .form-element.check-only
     = f.input :check_number

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,12 +22,17 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
-  .form-element.disbursement-only
-    = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
   .view-element
     = f.input :qb_object_subtype
       - if @transaction.qb_object_subtype
         = @transaction.qb_object_subtype.capitalize
+  .form-element.disbursement-only
+    - if @transaction.new_record?
+      = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+    - elsif @transaction.qb_object_subtype == "Check"
+      = f.input :qb_object_subtype
+        = @transaction.qb_object_subtype.capitalize
+
 
   .form-element.disbursement-only
     = f.association :vendor, collection: @vendors

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -12,7 +12,7 @@
 
   = f.hidden_field :project_id
 
-  = f.input :loan_transaction_type_value
+  = f.input :loan_transaction_type_value, wrapper_html: @transaction.new_record? ? {class: "principal-form-field"} : {} 
     .view-element
       - if @transaction.loan_transaction_type_value
         = @transaction.loan_transaction_type_value.capitalize

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,6 +22,9 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
+  // if new record, let js handle displaying or not.
+  // if not, only display if check because subtype null isn't meaningful to users
+  // .disbursement-only class lets js control display when new record
   - if @transaction.new_record? || @transaction.subtype?("check")
     = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
       .view-element
@@ -30,9 +33,10 @@
       .form-element
         - if @transaction.new_record?
           = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
-        - elsif @transaction.qb_object_subtype == "Check"
-            = @transaction.qb_object_subtype.capitalize
+        - else
+          = @transaction.qb_object_subtype.capitalize
 
+  // .disbursement-only class lets js control display when new record
   - if @transaction.new_record? || @transaction.type?("disbursement")
       .view-element
         - if @transaction.vendor
@@ -41,6 +45,7 @@
       .form-element
         = f.association :vendor, collection: @vendors, wrapper_html: {class: 'disbursement-only'}
 
+  // .check-only class lets js control display when new record
   - if @transaction.new_record? || @transaction.subtype?("Check")
     = f.input :check_number, wrapper_html: {class: 'check-only'}
       .view-element
@@ -48,7 +53,6 @@
           = @transaction.check_number
       .form-element
         = f.input_field :check_number
-
 
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,29 +22,32 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
-  = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
-    .view-element
-      - if @transaction.qb_object_subtype
-        = @transaction.qb_object_subtype.capitalize
-    .form-element
-      - if @transaction.new_record?
-        = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
-      - elsif @transaction.qb_object_subtype == "Check"
+  - if @transaction.new_record? || @transaction.subtype?("check")
+    = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
+      .view-element
+        - if @transaction.qb_object_subtype
           = @transaction.qb_object_subtype.capitalize
+      .form-element
+        - if @transaction.new_record?
+          = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+        - elsif @transaction.qb_object_subtype == "Check"
+            = @transaction.qb_object_subtype.capitalize
 
-  = f.input :vendor, wrapper_html: {class: 'disbursement-only'}
-    .view-element
-      - if @transaction.vendor
-        = @transaction.vendor.name
-    .form-element
-      = f.input_field :vendor, collection: @vendors
+  - if @transaction.new_record? || @transaction.type?("disbursement")
+      .view-element
+        - if @transaction.vendor
+          = f.input :vendor
+            = @transaction.vendor.name
+      .form-element
+        = f.association :vendor, collection: @vendors, wrapper_html: {class: 'disbursement-only'}
 
-  = f.input :check_number, wrapper_html: {class: 'check-only'}
-    .view-element
-      - if @transaction.check_number
-        = @transaction.check_number
-    .form-element
-      = f.input_field :check_number
+  - if @transaction.new_record? || @transaction.subtype?("Check")
+    = f.input :check_number, wrapper_html: {class: 'check-only'}
+      .view-element
+        - if @transaction.check_number
+          = @transaction.check_number
+      .form-element
+        = f.input_field :check_number
 
 
   = f.input :txn_date

--- a/app/views/admin/accounting/transactions/_modal_content.slim
+++ b/app/views/admin/accounting/transactions/_modal_content.slim
@@ -8,7 +8,7 @@ div.modal-header
       = @transaction.description
 
 div.modal-body
-  - unless @transaction.new_record?
+  - unless @transaction.new_record? || @transaction.type?("interest")
     .show-actions
       a.edit-action.view-element
         i.fa.fa-pencil.fa-large>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -239,7 +239,7 @@ en:
         principal_balance: "Principal Balance"
         private_note: "Memo"
         qb_department: "QB Division"
-        qb_object_subtype: "Subtype of Transaction"
+        qb_object_subtype: "Disbursement Type"
         qb_record_id: "QuickBooks Record ID"
         total_balance: "Total Balance"
         txn_date: "Date"

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -96,15 +96,15 @@ feature 'transaction flow', :accounting do
       scenario 'disbursement and check fields' do
         visit "/admin/loans/#{loan.id}/transactions"
         click_on 'Add Transaction'
-        expect(page).not_to have_content('Subtype')
+        expect(page).not_to have_content('Disbursement Type')
         expect(page).not_to have_content('Vendor')
         expect(page).not_to have_content('Check Number')
         choose 'Disbursement'
-        expect(page).to have_content('Subtype')
+        expect(page).to have_content('Disbursement Type')
         expect(page).to have_content('Vendor')
         expect(page).not_to have_content('Check Number')
         choose 'Check'
-        expect(page).to have_content('Subtype')
+        expect(page).to have_content('Disbursement Type')
         expect(page).to have_content('Check Number')
         fill_in 'Check Number', with: 123
         select vendors.sample.name, from: 'Vendor'

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -168,7 +168,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
 
     def expect_line_item_amounts(amounts)
       amounts.each_with_index do |amt, i|
-        expect(txn.line_items[i].amount).to equal_money(amt)
+        expect(txn.line_items.order(:qb_line_id)[i].amount).to equal_money(amt)
       end
     end
 

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -111,7 +111,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
       end
 
       it 'updates correctly in Madeline' do
-        expect(txn.line_items.map(&:qb_line_id)).to eq([0, 1, 2, 3, 4])
+        expect(txn.line_items.map(&:qb_line_id).sort).to eq([0, 1, 2, 3, 4])
         expect(txn.line_items.map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit', 'Credit', 'Debit'])
         expect_line_item_amounts([10.99, 1.31, 12.30, 1.00, 1.00])
 

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -111,8 +111,8 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
       end
 
       it 'updates correctly in Madeline' do
-        expect(txn.line_items.map(&:qb_line_id).sort).to eq([0, 1, 2, 3, 4])
-        expect(txn.line_items.map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit', 'Credit', 'Debit'])
+        expect(txn.line_items.order(:qb_line_id).map(&:qb_line_id)).to eq([0, 1, 2, 3, 4])
+        expect(txn.line_items.order(:qb_line_id).map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit', 'Credit', 'Debit'])
         expect_line_item_amounts([10.99, 1.31, 12.30, 1.00, 1.00])
 
         # Amount is calculated from line items so this tests all of those calculations.


### PR DESCRIPTION
…books data

This was blessedly easy - basically a merge clean up. I just updated the check building code to use the sync_token field, and tested manually, thoroughly. 

Made disbursement type read-only when editing: 
<img width="785" alt="Screen Shot 2020-10-07 at 10 56 09 AM" src="https://user-images.githubusercontent.com/4730344/95348280-e0cdeb80-088b-11eb-9579-67fa4f62db01.png">

