### PR TITLE
11130 txn modal ux improvements

### DIFF
--- a/app/assets/stylesheets/admin/forms/_transaction_form.scss
+++ b/app/assets/stylesheets/admin/forms/_transaction_form.scss
@@ -5,6 +5,11 @@
     }
   }
 
+  .principal-form-field {
+    border-bottom: 1px solid $gray2;
+    padding-bottom: 10px;
+  }
+
   .transaction-amount {
     input {
       width: 10em;

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -212,6 +212,10 @@ class Accounting::Transaction < ApplicationRecord
     update_column(:needs_qb_push, value)
   end
 
+  def type?(type)
+    loan_transaction_type_value == type
+  end
+
   def subtype?(subtype)
     qb_object_subtype == subtype
   end

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -39,12 +39,13 @@
     .form-element
       = f.input_field :vendor, collection: @vendors
 
-  .form-element.check-only
-    = f.input :check_number
-  .view-element
-    = f.input :check_number
+  = f.input :check_number, wrapper_html: {class: 'check-only'}
+    .view-element
       - if @transaction.check_number
         = @transaction.check_number
+    .form-element
+      = f.input_field :check_number
+
 
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,16 +22,16 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
-  .view-element
-    = f.input :qb_object_subtype
+  = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
+    .view-element
       - if @transaction.qb_object_subtype
         = @transaction.qb_object_subtype.capitalize
-  .form-element.disbursement-only
-    - if @transaction.new_record?
-      = f.input :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
-    - elsif @transaction.qb_object_subtype == "Check"
-      = f.input :qb_object_subtype
-        = @transaction.qb_object_subtype.capitalize
+    .form-element
+      - if @transaction.new_record?
+        = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+      - elsif @transaction.qb_object_subtype == "Check"
+        = f.input :qb_object_subtype
+          = @transaction.qb_object_subtype.capitalize
 
 
   .form-element.disbursement-only

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -30,16 +30,14 @@
       - if @transaction.new_record?
         = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
       - elsif @transaction.qb_object_subtype == "Check"
-        = f.input :qb_object_subtype
           = @transaction.qb_object_subtype.capitalize
 
-
-  .form-element.disbursement-only
-    = f.association :vendor, collection: @vendors
-  .view-element
-    = f.input :vendor
+  = f.input :vendor, wrapper_html: {class: 'disbursement-only'}
+    .view-element
       - if @transaction.vendor
         = @transaction.vendor.name
+    .form-element
+      = f.input_field :vendor, collection: @vendors
 
   .form-element.check-only
     = f.input :check_number

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -12,7 +12,7 @@
 
   = f.hidden_field :project_id
 
-  = f.input :loan_transaction_type_value
+  = f.input :loan_transaction_type_value, wrapper_html: @transaction.new_record? ? {class: "principal-form-field"} : {} 
     .view-element
       - if @transaction.loan_transaction_type_value
         = @transaction.loan_transaction_type_value.capitalize

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,6 +22,9 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
+  // if new record, let js handle displaying or not.
+  // if not, only display if check because subtype null isn't meaningful to users
+  // .disbursement-only class lets js control display when new record
   - if @transaction.new_record? || @transaction.subtype?("check")
     = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
       .view-element
@@ -30,9 +33,10 @@
       .form-element
         - if @transaction.new_record?
           = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
-        - elsif @transaction.qb_object_subtype == "Check"
-            = @transaction.qb_object_subtype.capitalize
+        - else
+          = @transaction.qb_object_subtype.capitalize
 
+  // .disbursement-only class lets js control display when new record
   - if @transaction.new_record? || @transaction.type?("disbursement")
       .view-element
         - if @transaction.vendor
@@ -41,6 +45,7 @@
       .form-element
         = f.association :vendor, collection: @vendors, wrapper_html: {class: 'disbursement-only'}
 
+  // .check-only class lets js control display when new record
   - if @transaction.new_record? || @transaction.subtype?("Check")
     = f.input :check_number, wrapper_html: {class: 'check-only'}
       .view-element
@@ -48,7 +53,6 @@
           = @transaction.check_number
       .form-element
         = f.input_field :check_number
-
 
   = f.input :txn_date
     .view-element = ldate(@transaction.txn_date)

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -22,29 +22,32 @@
       - else
         = @transaction.loan_transaction_type_value.capitalize
 
-  = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
-    .view-element
-      - if @transaction.qb_object_subtype
-        = @transaction.qb_object_subtype.capitalize
-    .form-element
-      - if @transaction.new_record?
-        = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
-      - elsif @transaction.qb_object_subtype == "Check"
+  - if @transaction.new_record? || @transaction.subtype?("check")
+    = f.input :qb_object_subtype, wrapper_html: {class: 'disbursement-only'}
+      .view-element
+        - if @transaction.qb_object_subtype
           = @transaction.qb_object_subtype.capitalize
+      .form-element
+        - if @transaction.new_record?
+          = f.input_field :qb_object_subtype, collection: @qb_subtypes, as: :radio_buttons
+        - elsif @transaction.qb_object_subtype == "Check"
+            = @transaction.qb_object_subtype.capitalize
 
-  = f.input :vendor, wrapper_html: {class: 'disbursement-only'}
-    .view-element
-      - if @transaction.vendor
-        = @transaction.vendor.name
-    .form-element
-      = f.input_field :vendor, collection: @vendors
+  - if @transaction.new_record? || @transaction.type?("disbursement")
+      .view-element
+        - if @transaction.vendor
+          = f.input :vendor
+            = @transaction.vendor.name
+      .form-element
+        = f.association :vendor, collection: @vendors, wrapper_html: {class: 'disbursement-only'}
 
-  = f.input :check_number, wrapper_html: {class: 'check-only'}
-    .view-element
-      - if @transaction.check_number
-        = @transaction.check_number
-    .form-element
-      = f.input_field :check_number
+  - if @transaction.new_record? || @transaction.subtype?("Check")
+    = f.input :check_number, wrapper_html: {class: 'check-only'}
+      .view-element
+        - if @transaction.check_number
+          = @transaction.check_number
+      .form-element
+        = f.input_field :check_number
 
 
   = f.input :txn_date

--- a/app/views/admin/accounting/transactions/_modal_content.slim
+++ b/app/views/admin/accounting/transactions/_modal_content.slim
@@ -8,7 +8,7 @@ div.modal-header
       = @transaction.description
 
 div.modal-body
-  - unless @transaction.new_record?
+  - unless @transaction.new_record? || @transaction.type?("interest")
     .show-actions
       a.edit-action.view-element
         i.fa.fa-pencil.fa-large>

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -168,7 +168,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
 
     def expect_line_item_amounts(amounts)
       amounts.each_with_index do |amt, i|
-        expect(txn.line_items[i].amount).to equal_money(amt)
+        expect(txn.line_items.order(:qb_line_id)[i].amount).to equal_money(amt)
       end
     end
 

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -111,8 +111,8 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
       end
 
       it 'updates correctly in Madeline' do
-        expect(txn.line_items.map(&:qb_line_id).sort).to eq([0, 1, 2, 3, 4])
-        expect(txn.line_items.map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit', 'Credit', 'Debit'])
+        expect(txn.line_items.order(:qb_line_id).map(&:qb_line_id)).to eq([0, 1, 2, 3, 4])
+        expect(txn.line_items.order(:qb_line_id).map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit', 'Credit', 'Debit'])
         expect_line_item_amounts([10.99, 1.31, 12.30, 1.00, 1.00])
 
         # Amount is calculated from line items so this tests all of those calculations.


### PR DESCRIPTION
UI changes to be ready for TWW testing editing txns. Changes are: 
- do not allow editing interest txns
- hide irrelevant fields on show and edit 
         - hide disbursement type, vendor, check number for non-disbursements
         - hide disbursement type, check number for non check txns
- add a line below txn type on `new` view for visual hierarchy. Txn type field being read-only helps with visual hierarchy in edit. This needs UX review. 
- change 'Subtype of Transaction' to 'Disbursement Type'

New txn view wide screen:
<img width="1212" alt="Screen Shot 2020-10-08 at 8 25 50 AM" src="https://user-images.githubusercontent.com/4730344/95461151-e0912700-0943-11eb-9069-7ec2a1f3bd09.png">

New txn view narrow screen:
<img width="728" alt="Screen Shot 2020-10-08 at 8 25 39 AM" src="https://user-images.githubusercontent.com/4730344/95461737-96f50c00-0944-11eb-9ee9-6cde46c1fd55.png">

Show interest txn (no "edit" option): 
<img width="822" alt="Screen Shot 2020-10-08 at 8 43 00 AM" src="https://user-images.githubusercontent.com/4730344/95461785-a411fb00-0944-11eb-9d6b-402f6fce66fc.png">




