### PR TITLE
11102: run update at end of full fetcher

### DIFF
--- a/app/models/accounting/qb/full_fetcher.rb
+++ b/app/models/accounting/qb/full_fetcher.rb
@@ -70,7 +70,7 @@ module Accounting
 
       def clear_department_associations!
         department_division_map = {}
-        Accounting::QB::Department.all.each do |d|
+        Accounting::QB::Department.find_each do |d|
           department_division_map[d.qb_id] = d.division_id
         end
         department_division_map
@@ -91,7 +91,7 @@ module Accounting
       end
 
       def restore_department_associations!(department_division_map)
-        Accounting::QB::Department.all.each do |d|
+        Accounting::QB::Department.find_each do |d|
           d.update_attribute(:division_id, department_division_map[d.qb_id])
         end
       end

--- a/app/models/accounting/qb/full_fetcher.rb
+++ b/app/models/accounting/qb/full_fetcher.rb
@@ -15,6 +15,11 @@ module Accounting
         delete_qb_data
         fetch_qb_data
         restore_accounts!(accounts)
+        Task.create(
+          job_class: UpdateAllLoansJob,
+          job_type_value: 'update_all_loans',
+          activity_message_value: 'task_enqueued'
+        ).enqueue
       rescue StandardError => error
         @qb_connection&.destroy
         raise error

--- a/spec/models/accounting/qb/full_fetcher_spec.rb
+++ b/spec/models/accounting/qb/full_fetcher_spec.rb
@@ -35,12 +35,13 @@ describe Accounting::QB::FullFetcher, type: :model do
   end
   let(:qb_transaction_service) { instance_double(Quickbooks::Service::JournalEntry, all: []) }
   let(:qb_customer_service) { instance_double(Quickbooks::Service::Customer, all: []) }
-  let(:qb_department_service) { instance_double(Quickbooks::Service::Department, all: [
+  let(:qb_department_service) {
+    instance_double(Quickbooks::Service::Department, all: [
       instance_double(Quickbooks::Model::Department,
         id: qb_department.qb_id,
-        name: qb_department.name
-      )
-    ]) }
+        name: qb_department.name)
+    ])
+  }
   let(:qb_vendor_service) { instance_double(Quickbooks::Service::Vendor, all: []) }
   let(:account_fetcher) { Accounting::QB::AccountFetcher.new(division) }
   let!(:account_fetcher_class) {


### PR DESCRIPTION


easy peasy. I manually tested in sandbox and it went fine. We can keep an eye on it on staging, but no reason to think it won't work. 

update all loans task ran after full fetch: 
<img width="978" alt="Screen Shot 2020-10-16 at 10 24 59 AM" src="https://user-images.githubusercontent.com/4730344/96270647-ef0dbd00-0f99-11eb-8037-4079d44e626a.png">