### PR TITLE
11255: ensure doc number always updated when writing to qb

### DIFF
--- a/app/models/accounting/qb/transaction_builder.rb
+++ b/app/models/accounting/qb/transaction_builder.rb
@@ -34,10 +34,8 @@ module Accounting
         if transaction.qb_id
           p.id = transaction.qb_id
           p.sync_token = transaction.sync_token
-        else
-          p.doc_number = set_journal_number(transaction)
         end
-
+        p.doc_number = set_journal_number(transaction)
         p.private_note = transaction.private_note
         p.txn_date = transaction.txn_date if transaction.txn_date.present?
         p.account_ref = transaction.account.try(:reference)


### PR DESCRIPTION
This is a small fix, that I manually tested in my dev environment. In the txn builder, the doc number (also known as journal number or check number) was only being set on new txns, not if the txn had a qb id. Now it's always set. 