### PR TITLE
11285 enhanced data export crash

### DIFF
--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -23,7 +23,6 @@
 #
 
 class EnhancedLoanDataExport < DataExport
-
   Q_DATA_TYPES = ['number', 'percentage', 'rating', 'currency']
   BASE_HEADERS = [
     'loan_id',

--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -62,17 +62,13 @@ class EnhancedLoanDataExport < DataExport
     data = []
     data << header_row
     data << question_id_row
-    num_loans_so_far = 0
     Loan.find_each do |loan|
-      pp "loan #{loan.id}"
       begin
         data << hash_to_row(loan_data_as_hash(loan))
       rescue => e
         @child_errors << {loan_id: loan.id, message: e.message}
         next
       end
-      num_loans_so_far = num_loans_so_far + 1
-      pp "loans so far: #{num_loans_so_far}"
     end
     self.update(data: data)
 


### PR DESCRIPTION
This issue should be released in 3.15.1, to staging and production today (Fri Nov 13, 2020)

Updated to remove lines that were triggering unnecessary recursive db activity (see details in the comment in the file). This task runs in <2 mins on staging :D. See "updated version of enhanced data export" at https://ms-staging.theworkingworld.org/admin/data-exports for example output

