### PR TITLE
11253 balances not calced for some loans

### DIFF
--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -81,7 +81,7 @@ module Accounting
       # Creates/deletes LineItems as needed.
       def extract_qb_data(loan)
         if loan.transactions.present?
-          loan.transactions.each do |txn|
+          loan.transactions.standard_order.each do |txn|
             if txn.quickbooks_data.present?
               Accounting::QB::DataExtractor.new(txn).extract!
               txn.save!

--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -61,7 +61,13 @@ module Accounting
         end
       end
 
-      # updates single loan
+      # To update a loan, we first must extract any new qb data on its txns.
+      # Then we run the interest calculator, which depends on extracted qb data.
+      # Though interest calculation calculates balances on any loans whose interest
+      # is calculated, we call calculate balances again after the interest calculation
+      # because not all loans have their interest calculated in 'recalculate', but all loans need
+      # their balances calculated. Note: attempting to calculate balances
+      # on all loans before interest calculation has caused problems in the past.
       def update_loan(loan)
         extract_qb_data(loan)
         InterestCalculator.new(loan).recalculate

--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -75,7 +75,7 @@ module Accounting
       # Creates/deletes LineItems as needed.
       def extract_qb_data(loan)
         if loan.transactions.present?
-          loan.transactions.standard_order.each do |txn|
+          loan.transactions.each do |txn|
             if txn.quickbooks_data.present?
               Accounting::QB::DataExtractor.new(txn).extract!
               txn.save!

--- a/app/views/admin/accounting/transactions/_form.slim
+++ b/app/views/admin/accounting/transactions/_form.slim
@@ -67,7 +67,7 @@
 
   = f.input :qb_department
     .form-element
-      = (@transaction.qb_department ? @transaction.qb_department.name : t('quickbooks.department_not_set', url: admin_division_path(@project.division)).html_safe)
+      = (@transaction.qb_department ? @transaction.qb_department.name : t('quickbooks.department_not_set', url: admin_division_path(@transaction.division)).html_safe)
     .view-element
       - if @transaction.qb_department
         = @transaction.qb_department.name

--- a/spec/models/accounting/qb/updater_spec.rb
+++ b/spec/models/accounting/qb/updater_spec.rb
@@ -265,13 +265,14 @@ RSpec.describe Accounting::QB::Updater, type: :model do
 
   describe 'extract_qb_data' do
     let(:txn) {
-      build(:accounting_transaction, project: loan, quickbooks_data: quickbooks_data,
-                                     loan_transaction_type_value: nil, account: txn_acct)
+      build(:accounting_transaction, project: loan, quickbooks_data: quickbooks_data)
     }
 
     it 'data persists from the extractor to the updater' do
-      # the quickbooks_data variable on line 19 matches a repayment type
-      expect(subject.send(:extract_qb_data, txn).loan_transaction_type_value).to eq('repayment')
+      # the quickbooks_data variable matches a repayment type
+      txn.save(validate: false) # mimic create_or_update_from_qb_object in transaction model
+      subject.send(:extract_qb_data, loan)
+      expect(loan.transactions.first.reload.loan_transaction_type_value).to eq('repayment')
     end
   end
 end


### PR DESCRIPTION
So we learned when we need to call calculate balances in the updater - if a loan shouldn't have interest calculation run, we still need to calculate balances for it. This has a first pass at those changes. I wanted to get your feedback before going farther. . . 