### PR TITLE
11254 txn modal edit new bug

### DIFF
--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -11,8 +11,7 @@ class MS.Views.TransactionModalView extends Backbone.View
     @loanId = params.loanId
     @locale = params.locale # need this later for description, keep
 
-  show: (txn_id, action) ->
-    console.log("refactored_show")
+  showModal: (txn_id, action) ->
     if action == "new"
       url = "/admin/accounting/transactions/new"
     else

--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -10,25 +10,14 @@ class MS.Views.TransactionModalView extends Backbone.View
   initialize: (params) ->
     @loanId = params.loanId
     @locale = params.locale # need this later for description, keep
-    #url = "/admin/accounting/transactions/new"
-    #@loadContent(url, @loanId, 'new')
 
-  refactored_show: (txn_id, action) ->
+  show: (txn_id, action) ->
     console.log("refactored_show")
     if action == "new"
       url = "/admin/accounting/transactions/new"
     else
       url = "/admin/loans/#{@loanId}/transactions/#{txn_id}"
     @loadContent(url, @loanId, action)
-
-
-  show: (id, loanId) ->
-    # DO need id, because it is determined dynamically based on which row the user clicked
-    # theoretically we shouldn't need the loan id here; can use @loanId set in initialize via constructor
-    @loanId = loanId
-    # console.log("take a beat in show")
-    url = "/admin/loans/#{loanId}/transactions/#{id}"
-    @loadContent(url, loanId, 'show')
 
   loadContent: (url, loanId, action) ->
     $.get url, project_id: loanId, (html) =>

--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -9,7 +9,7 @@ class MS.Views.TransactionModalView extends Backbone.View
 
   initialize: (params) ->
     @loanId = params.loanId
-    @locale = params.locale # need this later for description, keep
+    @locale = params.locale
 
   showModal: (txn_id, action) ->
     if action == "new"

--- a/app/assets/javascripts/admin/transaction_modal_view.coffee
+++ b/app/assets/javascripts/admin/transaction_modal_view.coffee
@@ -9,12 +9,24 @@ class MS.Views.TransactionModalView extends Backbone.View
 
   initialize: (params) ->
     @loanId = params.loanId
-    @locale = params.locale
-    url = "/admin/accounting/transactions/new"
-    @loadContent(url, @loanId, 'new')
+    @locale = params.locale # need this later for description, keep
+    #url = "/admin/accounting/transactions/new"
+    #@loadContent(url, @loanId, 'new')
+
+  refactored_show: (txn_id, action) ->
+    console.log("refactored_show")
+    if action == "new"
+      url = "/admin/accounting/transactions/new"
+    else
+      url = "/admin/loans/#{@loanId}/transactions/#{txn_id}"
+    @loadContent(url, @loanId, action)
+
 
   show: (id, loanId) ->
+    # DO need id, because it is determined dynamically based on which row the user clicked
+    # theoretically we shouldn't need the loan id here; can use @loanId set in initialize via constructor
     @loanId = loanId
+    # console.log("take a beat in show")
     url = "/admin/loans/#{loanId}/transactions/#{id}"
     @loadContent(url, loanId, 'show')
 

--- a/app/assets/javascripts/admin/transactions_view.coffee
+++ b/app/assets/javascripts/admin/transactions_view.coffee
@@ -17,6 +17,6 @@ class MS.Views.TransactionsView extends Backbone.View
       @transactionModalView = new MS.Views.TransactionModalView({loanId: @loanId, locale: @locale})
 
     if action == 'new-transaction'
-      @transactionModalView.show(null, "new")
+      @transactionModalView.showModal(null, "new")
     else
-      @transactionModalView.show(@$(link).data('id'), "show")
+      @transactionModalView.showModal(@$(link).data('id'), "show")

--- a/app/assets/javascripts/admin/transactions_view.coffee
+++ b/app/assets/javascripts/admin/transactions_view.coffee
@@ -13,14 +13,10 @@ class MS.Views.TransactionsView extends Backbone.View
     e.preventDefault()
     link = e.currentTarget
     action = @$(link).data('action')
-    console.log(action)
     unless @transactionModalView
-      console.log("instantiating new txn modal view")
       @transactionModalView = new MS.Views.TransactionModalView({loanId: @loanId, locale: @locale})
 
     if action == 'new-transaction'
-      @transactionModalView.refactored_show(null, "new")
-      #@transactionModalView = new MS.Views.TransactionModalView({loanId: @loanId, locale: @locale})
-      #@transactionModalView.initialize({loanId: @$(link).data('project-id'), locale: @locale})
+      @transactionModalView.show(null, "new")
     else
-      @transactionModalView.refactored_show(@$(link).data('id'), "show")
+      @transactionModalView.show(@$(link).data('id'), "show")

--- a/app/assets/javascripts/admin/transactions_view.coffee
+++ b/app/assets/javascripts/admin/transactions_view.coffee
@@ -13,11 +13,14 @@ class MS.Views.TransactionsView extends Backbone.View
     e.preventDefault()
     link = e.currentTarget
     action = @$(link).data('action')
-
+    console.log(action)
     unless @transactionModalView
+      console.log("instantiating new txn modal view")
       @transactionModalView = new MS.Views.TransactionModalView({loanId: @loanId, locale: @locale})
 
     if action == 'new-transaction'
-      @transactionModalView.initialize({loanId: @$(link).data('project-id'), locale: @locale})
+      @transactionModalView.refactored_show(null, "new")
+      #@transactionModalView = new MS.Views.TransactionModalView({loanId: @loanId, locale: @locale})
+      #@transactionModalView.initialize({loanId: @$(link).data('project-id'), locale: @locale})
     else
-      @transactionModalView.show(@$(link).data('id'), @$(link).data('project-id'))
+      @transactionModalView.refactored_show(@$(link).data('id'), "show")


### PR DESCRIPTION
Diagnosis: pre-existing code called loadContent for a new loan in `initialize.` Since `initialize` is called in the constructor, if the modal had not yet been initialized when the user clicks an existing txn there was a race condition between two calls to loadContent completing - one for 'new' and one for the existing txn.

Fix: move loadContent call out of initialize. Call `showModal` for both new and existing txns, and handle conditional logic for args to loadContent there. 