### PR TITLE
11301: set txn description to match first line item description in tx…

### DIFF
--- a/app/models/accounting/qb/transaction_extractor.rb
+++ b/app/models/accounting/qb/transaction_extractor.rb
@@ -67,6 +67,7 @@ module Accounting
         txn.private_note = txn.quickbooks_data['private_note']
         txn.total = txn.quickbooks_data['total']
         txn.currency = lookup_currency
+        txn.description = txn.line_items.first.try(:description)
       end
 
       def set_type


### PR DESCRIPTION
…n extractor. Fixes problem with qb udpates to desc not showing in madeline UI, and mirrors txn builder where li descs are set to txn desc.

Previously, edits to txn descirptions made in qb were not visible in madeline UI. The txn extractor updated madeline line item descriptions to match qb line item descriptions, but madeline li descriptoins do not show in the interface. Now when we import a txn, the txn's description is updated to match its first line item description. 