### PR TITLE
11384: add rbenv_rake job type that inits rbenv vars and use in staging

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,13 +9,11 @@ every 1.day, at: '3am' do
   runner 'RecalculateAllLoanHealthJob.perform_later'
 end
 
-case @environment
-when 'production'
-  every 1.day, at: '2am' do
+every 1.day, at: '2am' do
+  case @environment
+  when 'production'
     rake "madeline:enqueue_update_loans_task"
-  end
-when 'staging'
-  every 1.day, at: '2am' do
+  when 'staging'
     rbenv_rake "madeline:enqueue_update_loans_task"
   end
 end


### PR DESCRIPTION
rbenv vars aren't available to cron by default. based on this post: https://benscheirman.com/2013/12/using-rbenv-in-cron-jobs/ . . . i created an rbenv_rake job to use in staging. After prod server is rebuilt, presumably using rbenv vars, we'll take out the conditional statement. 

on my local, the rbenv_rake job in whenever writes this to my crontab, which is what worked when i tried it on staging: `0 2 * * * /bin/bash -l -c 'eval "$(rbenv init -)"; cd /Users/leaf/Sassafras/Projects/Madeline/madeline && bundle exec rake madeline:enqueue_update_loans_task --silent >> log/cron.log 2>&1'`

i'll need to double check the cron file and watch it when we deploy. 