### PR TITLE
11350 biz plan outline AND 11369 optional qs biz plan tree

### DIFF
--- a/app/assets/javascripts/admin/loan_questionnaires_view.coffee
+++ b/app/assets/javascripts/admin/loan_questionnaires_view.coffee
@@ -59,8 +59,7 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
         $question = @$(".question[data-id=#{node.id}]")
         $li.attr('data-id', node.id)
             .addClass($question.attr('class'))
-
-        if node.id == 'optional_group'
+        if node.id.toString().includes('optional_group')
           $li.addClass('optional-group')
         else
           $li.find('.jqtree-title')
@@ -68,22 +67,23 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
 
     # Load the data into each tree from its 'data-data' attribute.
     @tree.each (index, tree) =>
-      data = @groupOptional($(tree).data 'data')
+      data = @groupOptional($(tree).data('data'), 'root')
       $(tree).tree 'loadData', data
 
   # Note: the grouping of optional questions that happens here and in _questionnaire_group
   # should probably be refactored someday to happen in the model
-  groupOptional: (nodes) ->
+  groupOptional: (nodes, parentId) ->
     optionalGroupName = I18n.t('questionnaires.optional_questions', locale: @locale)
 
     # Recurse, depth first
     for node in nodes
       if node.children?.length
-        node.children = @groupOptional(node.children)
+        node.children = @groupOptional(node.children, node.id)
 
     if nodes.some( (el) -> el.optional ) && !nodes.every( (el) -> el.optional )
       # Add optional group to this level
-      nodes.push { id: 'optional_group', name: optionalGroupName, children: [] }
+      console.log(parentId)
+      nodes.push { id: "optional_group_#{parentId}", name: optionalGroupName, children: [] }
       optionalGroup = nodes[nodes.length - 1]
 
       for node in nodes

--- a/app/assets/javascripts/admin/loan_questionnaires_view.coffee
+++ b/app/assets/javascripts/admin/loan_questionnaires_view.coffee
@@ -82,7 +82,6 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
 
     if nodes.some( (el) -> el.optional ) && !nodes.every( (el) -> el.optional )
       # Add optional group to this level
-      console.log(parentId)
       nodes.push {id: "optional_group_#{parentId}", name: optionalGroupName, children: []}
       optionalGroup = nodes[nodes.length - 1]
 

--- a/app/assets/javascripts/admin/loan_questionnaires_view.coffee
+++ b/app/assets/javascripts/admin/loan_questionnaires_view.coffee
@@ -126,5 +126,5 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
     # @$('#jqtree').tree('openNode', jqtreeNode)
     jqtreeNodeToOpen = @$("#jqtree").tree('getNodeById', sectionId)
     @$('#jqtree').tree('openNode', jqtreeNodeToOpen)
-    # need to toggle node if closed
+    # TODO: call following in on_finished callback as third art to openNode
     $("li[data-id=\"#{  scrollTargetId}\"]")[0].scrollIntoView(true)

--- a/app/assets/javascripts/admin/loan_questionnaires_view.coffee
+++ b/app/assets/javascripts/admin/loan_questionnaires_view.coffee
@@ -83,7 +83,7 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
     if nodes.some( (el) -> el.optional ) && !nodes.every( (el) -> el.optional )
       # Add optional group to this level
       console.log(parentId)
-      nodes.push { id: "optional_group_#{parentId}", name: optionalGroupName, children: [] }
+      nodes.push {id: "optional_group_#{parentId}", name: optionalGroupName, children: []}
       optionalGroup = nodes[nodes.length - 1]
 
       for node in nodes

--- a/app/assets/javascripts/admin/loan_questionnaires_view.coffee
+++ b/app/assets/javascripts/admin/loan_questionnaires_view.coffee
@@ -25,6 +25,7 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
     'cut .answer-wrapper textarea': 'adjustTextArea'
     'clear .answer-wrapper textarea': 'adjustTextArea'
     'click .edit-rt-response': 'openRichTextModal'
+    'click a.deep-link': 'scrollElementToView'
 
   # Add a custom event for tree expansion. This event is listened to by LoanChartsView.
   notifyExpandListeners: (e) ->
@@ -115,3 +116,15 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
 
   openRichTextModal: (e) ->
     @richTextModalView.prepForm(e)
+
+  scrollElementToView: (e) ->
+    e.preventDefault()
+
+    scrollTargetId = @$(e.target).data("outline-id")
+    sectionId = @$(e.target).data("section-id")
+    # jqtreeNode = @$("#jqtree").tree('getNodeById', linkId)
+    # @$('#jqtree').tree('openNode', jqtreeNode)
+    jqtreeNodeToOpen = @$("#jqtree").tree('getNodeById', sectionId)
+    @$('#jqtree').tree('openNode', jqtreeNodeToOpen)
+    # need to toggle node if closed
+    $("li[data-id=\"#{  scrollTargetId}\"]")[0].scrollIntoView(true)

--- a/app/assets/stylesheets/admin/loans/_questionnaires.scss
+++ b/app/assets/stylesheets/admin/loans/_questionnaires.scss
@@ -152,7 +152,6 @@ section.questionnaires {
     // When position is fixed, the entire webpage/viewport is the parent element
     position: fixed;
     bottom: 0;
-    right: $content-wrapper-padding;
     display: block;
     margin: 0 0 $content-wrapper-padding;
     padding: 1em;

--- a/app/assets/stylesheets/admin/loans/_questionnaires.scss
+++ b/app/assets/stylesheets/admin/loans/_questionnaires.scss
@@ -12,6 +12,7 @@ section.questionnaires {
     border: none;
     margin-bottom: 3px;
     padding-bottom: 0.1px; // prevent margin collapse
+    scroll-margin-top: 100px;
 
     &.jqtree-folder.jqtree-closed {
       margin-bottom: 3px;

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -33,14 +33,9 @@
 
   .outline > ul {
     padding-left: 0;
-    > ul {
-      padding-left: 0;
-      > ul {
-        padding-left: 15px;
-        > ul {
-          padding-left: 15px;
-        }
-      }
+    ul {
+      padding-left: 15px;
+      padding-top: 10px;
     }
   }
 }

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -19,16 +19,13 @@
   }
 
   .outline > ul {
-    padding-left: 0px;
-    & > ul {
-      padding-left: 0px;
-      & > ul {
+    padding-left: 0;
+    > ul {
+      padding-left: 0;
+      > ul {
         padding-left: 15px;
-        & > ul {
+        > ul {
           padding-left: 15px;
-          & > ul {
-            padding-left: 15px;
-          }
         }
       }
     }

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -1,29 +1,31 @@
 .container {
-  width: 100%;
   padding-left: 0;
   padding-right: 0;
+  width: 100%;
 
   .row {
     .col-sm {
-      width: 20%;
       margin-top: 7px;
+      width: 20%;
     }
+
     .col-lg {
       width: 78%;
     }
+
     display: flex;
     flex-direction: row;
     justify-content: space-around;
 
     .outline {
-      background-color: white;
-      padding: 10px;
-      //width: 100%;
+      background-color: $white;
       border-radius: 4px;
       margin-top: 7px;
+      padding: 10px;
 
       ul {
-        list-style-type:none;
+        list-style-type: none;
+
         li {
           padding-bottom: 10px;
         }
@@ -51,12 +53,12 @@
   }
 }
 
-  .questionnaire {
-    .block {
-      margin-top: 0;
-      padding-top: 0;
-    }
+.questionnaire {
+  .block {
+    margin-top: 0;
+    padding-top: 0;
   }
+}
 
 .loan-questions {
   .filter-switch {

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -37,6 +37,14 @@
       padding-left: 15px;
       padding-top: 10px;
     }
+    .optional_link {
+      font-style: italic;
+    }
+    a:focus {
+      color:#000000;
+      font-weight: bold;
+      text-decoration: none;
+    }
   }
 }
 

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -1,20 +1,33 @@
-.container .row {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
+.container {
+  width: 100%;
+  padding-left: 0;
+  padding-right: 0;
 
-  .outline {
-    background-color: white;
-    padding: 10px;
-    width: 100%;
-    border-radius: 4px;
-    margin-top: 7px;
-  }
+  .row {
+    .col-sm {
+      width: 20%;
+      margin-top: 7px;
+    }
+    .col-lg {
+      width: 78%;
+    }
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
 
-  .outline ul {
-    list-style-type:none;
-    li {
-      padding-bottom: 10px;
+    .outline {
+      background-color: white;
+      padding: 10px;
+      //width: 100%;
+      border-radius: 4px;
+      margin-top: 7px;
+
+      ul {
+        list-style-type:none;
+        li {
+          padding-bottom: 10px;
+        }
+      }
     }
   }
 
@@ -30,6 +43,7 @@
       }
     }
   }
+}
 
   .questionnaire {
     .block {
@@ -37,7 +51,6 @@
       padding-top: 0;
     }
   }
-}
 
 .loan-questions {
   .filter-switch {

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -44,7 +44,7 @@
     }
 
     a:focus {
-      color: black;
+      color: $black;
       font-weight: bold;
       text-decoration: none;
     }

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -33,15 +33,18 @@
 
   .outline > ul {
     padding-left: 0;
+
     ul {
       padding-left: 15px;
       padding-top: 10px;
     }
-    .optional_link {
+
+    .optional-link {
       font-style: italic;
     }
+
     a:focus {
-      color:#000000;
+      color: black;
       font-weight: bold;
       text-decoration: none;
     }

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -1,3 +1,47 @@
+.container .row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+
+  .outline {
+    background-color: white;
+    padding: 10px;
+    width: 100%;
+    border-radius: 4px;
+    margin-top: 7px;
+  }
+
+  .outline ul {
+    list-style-type:none;
+    li {
+      padding-bottom: 10px;
+    }
+  }
+
+  .outline > ul {
+    padding-left: 0px;
+    & > ul {
+      padding-left: 0px;
+      & > ul {
+        padding-left: 15px;
+        & > ul {
+          padding-left: 15px;
+          & > ul {
+            padding-left: 15px;
+          }
+        }
+      }
+    }
+  }
+
+  .questionnaire {
+    .block {
+      margin-top: 0;
+      padding-top: 0;
+    }
+  }
+}
+
 .loan-questions {
   .filter-switch {
     padding-bottom: 20px;

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -31,7 +31,7 @@ section.questionnaires
       div.container
         div.row
           div.col-sm.outline
-            h4 = "Outline"
+            h4 = t("admin.loans.questions.outline.header")
             = render "admin/loans/questionnaires/questionnaire_outline", questions: @root.children, depth: 0, parent: @root
           div.col-lg
             = render partial: "admin/loans/questionnaires/questionnaire_form",

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -12,6 +12,9 @@ section.questionnaires
         admin_loan_tab_path(@loan.id, filter: "post_analysis", tab: "questions"),
         class: "btn btn-default #{'active' if @attrib == 'post_analysis'}",
         data: {filter: "post_analysis"}
+  div.outline
+    = link_to "Link to Group", {}, class: "deep-link", data: { id: 321 }
+    = render "admin/loans/questionnaires/questionnaire_outline", question: @root, depth: 0, section_id: nil
 
   div.questionnaire data-attrib=@attrib class=@attrib
     section.block class=(@response_set.persisted? && @response_set.valid? && !@conflict ? 'show-view' : 'edit-view')

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -12,31 +12,32 @@ section.questionnaires
         admin_loan_tab_path(@loan.id, filter: "post_analysis", tab: "questions"),
         class: "btn btn-default #{'active' if @attrib == 'post_analysis'}",
         data: {filter: "post_analysis"}
-  h2 = t("loan.#{@attrib}")
-  div.container
-    div.row
-      div.col-sm.outline
-        h4 = "Outline"
-        = render "admin/loans/questionnaires/questionnaire_outline", question: @root, depth: 0, section_id: nil
 
-      div.questionnaire.col-lg data-attrib=@attrib class=@attrib
-        section.block class=(@response_set.persisted? && @response_set.valid? && !@conflict ? 'show-view' : 'edit-view')
-          .show-actions
-            - if policy(@loan).update? && @response_set.persisted?
-              a.edit-action.view-element href="javascript:void(0)"
-                i.fa.fa-pencil.fa-large>
-                = t(".edit")
-              a.show-action.form-element href="javascript:void(0)"
-                = t("cancel_edit")
-              = link_to [:admin, @response_set], method: :delete,
-                data: { confirm: t("loan.confirm_response_deletion") }
-                i.fa.fa-trash.fa-large>
-                = t(".delete")
+  div.questionnaire data-attrib=@attrib class=@attrib
+    section.block class=(@response_set.persisted? && @response_set.valid? && !@conflict ? 'show-view' : 'edit-view')
+      .show-actions
+        - if policy(@loan).update? && @response_set.persisted?
+          a.edit-action.view-element href="javascript:void(0)"
+            i.fa.fa-pencil.fa-large>
+            = t(".edit")
+          a.show-action.form-element href="javascript:void(0)"
+            = t("cancel_edit")
+          = link_to [:admin, @response_set], method: :delete,
+            data: { confirm: t("loan.confirm_response_deletion") }
+            i.fa.fa-trash.fa-large>
+            = t(".delete")
 
-          = render partial: "admin/loans/questionnaires/questionnaire_form",
-                   locals: {response_set: @response_set, attrib: @attrib}
+      h2 = t("loan.#{@attrib}")
+      div.container
+        div.row
+          div.col-sm.outline
+            h4 = "Outline"
+            = render "admin/loans/questionnaires/questionnaire_outline", question: @root, depth: 0, section_id: nil
+          div.col-lg
+            = render partial: "admin/loans/questionnaires/questionnaire_form",
+                     locals: {response_set: @response_set, attrib: @attrib}
 
-  = render partial: "admin/loans/questionnaires/rich_text_modal"
+= render partial: "admin/loans/questionnaires/rich_text_modal"
 
 p.alert.alert-warning.hidden#rt-changes-warning
   button.close data-dismiss="alert" type="button"  &times;
@@ -57,12 +58,26 @@ javascript:
         $outlineHeight = $(".outline ul").height()
         $window    = $(window),
         offset     = $sidebar.offset(),
-        topPadding = 0;
+        topPadding = 15;
     $window.scroll(function() {
       if ($window.scrollTop() > (offset.top + $outlineHeight)) {
           $sidebar.css('margin-top', $window.scrollTop() - offset.top + topPadding)
       } else {
           $sidebar.css('margin-top', 0)
       }
+    });
+  });
+
+  $(function() {
+    var $editBar = $("#editBar")
+        $window    = $(window)
+    resizeEditBar = function () {
+      $editBar.css('width', $editBar.parent().width())
+    }
+    resizeEditBar()
+    $window.resize(function() {
+      console.log("resized! parent is this wide:")
+      console.log($editBar.parent().width())
+      $editBar.css('width', $editBar.parent().width())
     });
   });

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -12,29 +12,31 @@ section.questionnaires
         admin_loan_tab_path(@loan.id, filter: "post_analysis", tab: "questions"),
         class: "btn btn-default #{'active' if @attrib == 'post_analysis'}",
         data: {filter: "post_analysis"}
-  div.outline
-    = link_to "Link to Group", {}, class: "deep-link", data: { id: 321 }
-    = render "admin/loans/questionnaires/questionnaire_outline", question: @root, depth: 0, section_id: nil
+  h2 = t("loan.#{@attrib}")
+  div.container
+    div.row
+      div.col-sm.outline
+        h4 = "Outline"
+        = render "admin/loans/questionnaires/questionnaire_outline", question: @root, depth: 0, section_id: nil
 
-  div.questionnaire data-attrib=@attrib class=@attrib
-    section.block class=(@response_set.persisted? && @response_set.valid? && !@conflict ? 'show-view' : 'edit-view')
-      .show-actions
-        - if policy(@loan).update? && @response_set.persisted?
-          a.edit-action.view-element href="javascript:void(0)"
-            i.fa.fa-pencil.fa-large>
-            = t(".edit")
-          a.show-action.form-element href="javascript:void(0)"
-            = t("cancel_edit")
-          = link_to [:admin, @response_set], method: :delete,
-            data: { confirm: t("loan.confirm_response_deletion") }
-            i.fa.fa-trash.fa-large>
-            = t(".delete")
+      div.questionnaire.col-lg data-attrib=@attrib class=@attrib
+        section.block class=(@response_set.persisted? && @response_set.valid? && !@conflict ? 'show-view' : 'edit-view')
+          .show-actions
+            - if policy(@loan).update? && @response_set.persisted?
+              a.edit-action.view-element href="javascript:void(0)"
+                i.fa.fa-pencil.fa-large>
+                = t(".edit")
+              a.show-action.form-element href="javascript:void(0)"
+                = t("cancel_edit")
+              = link_to [:admin, @response_set], method: :delete,
+                data: { confirm: t("loan.confirm_response_deletion") }
+                i.fa.fa-trash.fa-large>
+                = t(".delete")
 
-      h2 = t("loan.#{@attrib}")
-      = render partial: "admin/loans/questionnaires/questionnaire_form",
-               locals: {response_set: @response_set, attrib: @attrib}
+          = render partial: "admin/loans/questionnaires/questionnaire_form",
+                   locals: {response_set: @response_set, attrib: @attrib}
 
-= render partial: "admin/loans/questionnaires/rich_text_modal"
+  = render partial: "admin/loans/questionnaires/rich_text_modal"
 
 p.alert.alert-warning.hidden#rt-changes-warning
   button.close data-dismiss="alert" type="button"  &times;
@@ -47,5 +49,23 @@ javascript:
     new MS.Views.LoanQuestionnairesView({
       loanId: #{@loan.id},
       locale: "#{I18n.locale}"
+    });
+  });
+
+  $(function() {
+    var $sidebar   = $(".outline"),
+        $window    = $(window),
+        offset     = $sidebar.offset(),
+        topPadding = 15;
+    $window.scroll(function() {
+      if ($window.scrollTop() > offset.top) {
+          $sidebar.stop().animate({
+              marginTop: $window.scrollTop() - offset.top + topPadding
+          });
+      } else {
+          $sidebar.stop().animate({
+              marginTop: 0
+          });
+      }
     });
   });

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -32,7 +32,7 @@ section.questionnaires
         div.row
           div.col-sm.outline
             h4 = "Outline"
-            = render "admin/loans/questionnaires/questionnaire_outline", questions: @root.children, depth: 0, parent_id: "root"
+            = render "admin/loans/questionnaires/questionnaire_outline", questions: @root.children, depth: 0, parent: @root
           div.col-lg
             = render partial: "admin/loans/questionnaires/questionnaire_form",
                      locals: {response_set: @response_set, attrib: @attrib}

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -32,7 +32,7 @@ section.questionnaires
         div.row
           div.col-sm.outline
             h4 = "Outline"
-            = render "admin/loans/questionnaires/questionnaire_outline", question: @root, depth: 0, section_id: nil
+            = render "admin/loans/questionnaires/questionnaire_outline", questions: @root.children, depth: 0, parent_id: "root"
           div.col-lg
             = render partial: "admin/loans/questionnaires/questionnaire_form",
                      locals: {response_set: @response_set, attrib: @attrib}

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -57,13 +57,15 @@ javascript:
     var $sidebar   = $(".outline"),
         $outlineHeight = $(".outline ul").height()
         $window    = $(window),
+        $containerHeight = $("#questions").height()
         offset     = $sidebar.offset(),
         topPadding = 15;
     $window.scroll(function() {
       if ($window.scrollTop() > (offset.top + $outlineHeight)) {
-          $sidebar.css('margin-top', $window.scrollTop() - offset.top + topPadding)
+        percentage = $window.scrollTop()/$containerHeight
+        $sidebar.css('margin-top', $window.scrollTop() - $outlineHeight * percentage)
       } else {
-          $sidebar.css('margin-top', 0)
+        $sidebar.css('margin-top',0)
       }
     });
   });

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -54,18 +54,15 @@ javascript:
 
   $(function() {
     var $sidebar   = $(".outline"),
+        $outlineHeight = $(".outline ul").height()
         $window    = $(window),
         offset     = $sidebar.offset(),
-        topPadding = 15;
+        topPadding = 0;
     $window.scroll(function() {
-      if ($window.scrollTop() > offset.top) {
-          $sidebar.stop().animate({
-              marginTop: $window.scrollTop() - offset.top + topPadding
-          });
+      if ($window.scrollTop() > (offset.top + $outlineHeight)) {
+          $sidebar.css('margin-top', $window.scrollTop() - offset.top + topPadding)
       } else {
-          $sidebar.stop().animate({
-              marginTop: 0
-          });
+          $sidebar.css('margin-top', 0)
       }
     });
   });

--- a/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
@@ -38,7 +38,7 @@
     = f.hidden_field(:lock_version)
 
     - unless @print_view
-      .jqtree data-data=@questions_json class=attrib
+      .jqtree data-data=@questions_json class=attrib id="jqtree"
 
     .actions.form-element
       p#unsaved-changes-warning.unsaved-changes-warning.hidden = t("loan.pending_changes_short")

--- a/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
@@ -40,7 +40,7 @@
     - unless @print_view
       .jqtree data-data=@questions_json class=attrib id="jqtree"
 
-    .actions.form-element
+    .actions.form-element#editBar
       p#unsaved-changes-warning.unsaved-changes-warning.hidden = t("loan.pending_changes_short")
       - unless response_set.new_record?
         a.btn.btn-default.show-action = t(:cancel)

--- a/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
@@ -8,4 +8,5 @@
    - if questions.any?(&:optional?)
      - optional_group_id = depth == 0 ? "optional_group_root" : "optional_group_#{parent.id}"
      li
-       = link_to "Optional Questions", {}, class: "deep-link", data: { outline_id: optional_group_id, section_id: optional_group_id }
+       - prefix = depth == 0 ? "All Other" : parent.label
+       = link_to "#{prefix} Optional Questions", {}, class: "deep-link", data: { outline_id: optional_group_id, section_id: optional_group_id }

--- a/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
@@ -7,6 +7,6 @@
       = render("admin/loans/questionnaires/questionnaire_outline", questions: q.children, depth: depth + 1, parent: q)
    - if questions.any?(&:optional?)
      - optional_group_id = depth == 0 ? "optional_group_root" : "optional_group_#{parent.id}"
-     li.optional_link
+     li.optional-link
        - postfix = depth == 0 ? t("admin.loans.questions.outline.miscellaneous") : parent.full_number_and_label
        = link_to "#{t("admin.loans.questions.outline.optional")}: #{postfix}", {}, class: "deep-link", data: { outline_id: optional_group_id, section_id: optional_group_id }

--- a/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
@@ -1,8 +1,13 @@
 ul
-    - if LoanFilteredQuestion.new(question, loan: @loan, user: @current_user).required? && depth > 0
+    - if depth > 0
       li
-        = link_to "#{question.full_number_and_label}", {}, class: "deep-link", data: { outline_id: question.id, section_id: section_id }
+        - if LoanFilteredQuestion.new(question, loan: @loan, user: @current_user).required?
+          = link_to "#{question.full_number_and_label}", {}, class: "deep-link", data: { outline_id: question.id, section_id: section_id }
     - if question.group? && depth < 2
       - question.children.each do |c|
         - section_id = c.id if depth == 0 # only set at top level
         = render("admin/loans/questionnaires/questionnaire_outline", question: c, depth: depth + 1, section_id: section_id)
+        - if question.children.any?(&:optional?)
+          - optional_group_id = "optional_group_#{section_id}"
+          li
+            = link_to "Optional Questions", {}, class: "deep-link", data: { outline_id: optional_group_id, section_id: optional_group_id }

--- a/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
@@ -1,5 +1,5 @@
-ul.outline
-    - if LoanFilteredQuestion.new(question, loan: @loan, user: @current_user).required?
+ul
+    - if LoanFilteredQuestion.new(question, loan: @loan, user: @current_user).required? && depth > 0
       li
         = link_to "#{question.full_number_and_label}", {}, class: "deep-link", data: { outline_id: question.id, section_id: section_id }
     - if question.group? && depth < 2

--- a/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
@@ -1,13 +1,11 @@
-ul
-    - if depth > 0
-      li
-        - if LoanFilteredQuestion.new(question, loan: @loan, user: @current_user).required?
-          = link_to "#{question.full_number_and_label}", {}, class: "deep-link", data: { outline_id: question.id, section_id: section_id }
-    - if question.group? && depth < 2
-      - question.children.each do |c|
-        - section_id = c.id if depth == 0 # only set at top level
-        = render("admin/loans/questionnaires/questionnaire_outline", question: c, depth: depth + 1, section_id: section_id)
-        - if question.children.any?(&:optional?)
-          - optional_group_id = "optional_group_#{section_id}"
-          li
-            = link_to "Optional Questions", {}, class: "deep-link", data: { outline_id: optional_group_id, section_id: optional_group_id }
+- if questions.present? && depth < 2 # base case is questions is nil
+ ul
+   - questions.select(&:required?).each do |q|
+    - section_id = ((depth == 0) ? q.id : parent_id)
+    li
+      = link_to "#{q.full_number_and_label}", {}, class: "deep-link", data: { outline_id: q.id, section_id: section_id }
+      = render("admin/loans/questionnaires/questionnaire_outline", questions: q.children, depth: depth + 1, parent_id: q.id)
+   - if questions.any?(&:optional?)
+     - optional_group_id = "optional_group_#{parent_id}"
+     li
+       = link_to "Optional Questions", {}, class: "deep-link", data: { outline_id: optional_group_id, section_id: optional_group_id }

--- a/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
@@ -1,0 +1,8 @@
+ul.outline
+    - if LoanFilteredQuestion.new(question, loan: @loan, user: @current_user).required?
+      li
+        = link_to "#{question.full_number_and_label}", {}, class: "deep-link", data: { outline_id: question.id, section_id: section_id }
+    - if question.group? && depth < 2
+      - question.children.each do |c|
+        - section_id = c.id if depth == 0 # only set at top level
+        = render("admin/loans/questionnaires/questionnaire_outline", question: c, depth: depth + 1, section_id: section_id)

--- a/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
@@ -7,6 +7,6 @@
       = render("admin/loans/questionnaires/questionnaire_outline", questions: q.children, depth: depth + 1, parent: q)
    - if questions.any?(&:optional?)
      - optional_group_id = depth == 0 ? "optional_group_root" : "optional_group_#{parent.id}"
-     li
-       - prefix = depth == 0 ? "All Other" : parent.label
-       = link_to "#{prefix} Optional Questions", {}, class: "deep-link", data: { outline_id: optional_group_id, section_id: optional_group_id }
+     li.optional_link
+       - postfix = depth == 0 ? t("admin.loans.questions.outline.miscellaneous") : parent.full_number_and_label
+       = link_to "#{t("admin.loans.questions.outline.optional")}: #{postfix}", {}, class: "deep-link", data: { outline_id: optional_group_id, section_id: optional_group_id }

--- a/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_outline.html.slim
@@ -1,11 +1,11 @@
 - if questions.present? && depth < 2 # base case is questions is nil
  ul
    - questions.select(&:required?).each do |q|
-    - section_id = ((depth == 0) ? q.id : parent_id)
+    - section_id = ((depth == 0) ? q.id : parent.id)
     li
       = link_to "#{q.full_number_and_label}", {}, class: "deep-link", data: { outline_id: q.id, section_id: section_id }
-      = render("admin/loans/questionnaires/questionnaire_outline", questions: q.children, depth: depth + 1, parent_id: q.id)
+      = render("admin/loans/questionnaires/questionnaire_outline", questions: q.children, depth: depth + 1, parent: q)
    - if questions.any?(&:optional?)
-     - optional_group_id = "optional_group_#{parent_id}"
+     - optional_group_id = depth == 0 ? "optional_group_root" : "optional_group_#{parent.id}"
      li
        = link_to "Optional Questions", {}, class: "deep-link", data: { outline_id: optional_group_id, section_id: optional_group_id }

--- a/config/locales/en/loans.en.yml
+++ b/config/locales/en/loans.en.yml
@@ -209,6 +209,10 @@ en:
       questions:
         edit: "Edit Responses"
         delete: "Delete All Responses"
+        outline:
+          header: "Outline"
+          optional: "Optional Qs"
+          miscellaneous: "Misc."
       transactions:
         create_success: "Transaction successfully created."
         update_success: "Transaction successfully updated."

--- a/config/locales/en/loans.en.yml
+++ b/config/locales/en/loans.en.yml
@@ -212,7 +212,7 @@ en:
         outline:
           header: "Outline"
           optional: "Optional Qs"
-          miscellaneous: "Misc."
+          miscellaneous: "Miscellaneous"
       transactions:
         create_success: "Transaction successfully created."
         update_success: "Transaction successfully updated."


### PR DESCRIPTION
Handles optional questions in the outline links; adds styling. Makes 11350 releasable. 

<img width="1389" alt="Screen Shot 2020-12-30 at 2 31 55 PM" src="https://user-images.githubusercontent.com/4730344/103377431-650bc580-4aad-11eb-808c-467d2f7eefb4.png">
<img width="1375" alt="Screen Shot 2020-12-30 at 2 17 10 PM" src="https://user-images.githubusercontent.com/4730344/103377447-6dfc9700-4aad-11eb-830f-aa340bf031fe.png">
