### PR TITLE
11378: fix respect_closed_book_date validation and set user_created i…

### DIFF
--- a/app/controllers/admin/accounting/transactions_controller.rb
+++ b/app/controllers/admin/accounting/transactions_controller.rb
@@ -53,10 +53,10 @@ class Admin::Accounting::TransactionsController < Admin::AdminController
     @transaction.attributes = transaction_params
 
     # Treat this like a new transaction
+    @transaction.user_created = true
     @transaction.quickbooks_data = nil
     @transaction.line_items.destroy_all
     @transaction.needs_qb_push = true
-
     process_transaction_and_handle_errors
 
     if @transaction.errors.any?

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -246,7 +246,8 @@ class Accounting::Transaction < ApplicationRecord
   end
 
   def respect_closed_books_date
-    return if division.closed_books_date.nil? || txn_date > division.closed_books_date
-    errors.add(:txn_date, :closed_books_date, date: division.closed_books_date)
+    cbd = Loan.find(project_id).qb_division.closed_books_date
+    return if cbd.nil? || txn_date > cbd
+    errors.add(:txn_date, :closed_books_date, date: cbd)
   end
 end

--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -246,7 +246,7 @@ class Accounting::Transaction < ApplicationRecord
   end
 
   def respect_closed_books_date
-    cbd = Loan.find(project_id).qb_division.closed_books_date
+    cbd = qb_division.closed_books_date
     return if cbd.nil? || txn_date > cbd
     errors.add(:txn_date, :closed_books_date, date: cbd)
   end


### PR DESCRIPTION
…n update method in controller so called when editing txns. 

before this, if I edited a txn to have a date before closed books date, i'd see an error from the txn builder about missing line items (because we don't update txns before closed books date). Now i'll see the correct notice that the date can't be before closed books date. 
<img width="786" alt="Screen Shot 2020-12-30 at 5 21 33 PM" src="https://user-images.githubusercontent.com/4730344/103385014-a52b7200-4ac6-11eb-94e8-969583291de5.png">
