### PR TITLE
11349: use filename not identifer on media item

### DIFF
--- a/app/assets/stylesheets/admin/media/_media.scss
+++ b/app/assets/stylesheets/admin/media/_media.scss
@@ -132,6 +132,7 @@ $data-export-media-block-width: auto;
 
 .media-gallery {
   background-color: $gray5;
+  min-width: 1500px; 
 
   .media-container {
     display: grid;
@@ -142,9 +143,14 @@ $data-export-media-block-width: auto;
     padding: 5px;
     margin-top: 0;
     .media-box {
+      display: flex;
       background-color: $white;
       padding: 0.5em;
       vertical-align: top;
+      height: 12.5em;
+      .media-left {
+        width: min-content;
+      }
       .media-caption span {
         display: block;
         height: 1.3em;

--- a/app/views/admin/media/_media_box.html.slim
+++ b/app/views/admin/media/_media_box.html.slim
@@ -13,7 +13,7 @@
           dd= media_item.kind_label
         .detail-group
           dt= t('media.block.filename')
-          dd= media_item.item.file.identifier
+          dd= media_item.item.file.filename
         .detail-group
           dt= t('media.block.date_uploaded')
           dd= l(media_item.created_at, format: :long)


### PR DESCRIPTION
Second PR from this branch to fix "media#index (ActionView::Template::Error) "undefined method `identifier' for #<CarrierWave::Storage::" error. Use 'filename' instead of 'identifier.