### PR TITLE
11666 fix edit bar on empty questionnaire

### DIFF
--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -14,7 +14,8 @@ section.questionnaires
         data: {filter: "post_analysis"}
 
   div.questionnaire data-attrib=@attrib class=@attrib
-    section.block class=(@response_set.persisted? && @response_set.valid? && !@conflict ? 'show-view' : 'edit-view')
+    //unlike other forms, we start in show view even with a new record
+    section.block class=(((@response_set.persisted? && @response_set.valid?) || @response_set.new_record? ) && !@conflict ? 'show-view' : 'edit-view')
       //hide delete link and see if there are any complaints before removing entirely
       / .show-actions
       /   - if policy(@loan).update? && @response_set.persisted?

--- a/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
@@ -45,8 +45,7 @@
         = fa_icon "exclamation-circle"
         = t("questions.currently_editing")
       p#unsaved-changes-warning.unsaved-changes-warning.hidden = t("loan.pending_changes_short")
-      - unless response_set.new_record?
-        a.btn.btn-default.show-action = t(:cancel)
+      a.btn.btn-default.show-action = t(:cancel)
       = f.submit t("loan.save_responses"), class: 'update-action btn btn-primary'
     .clearfix
 

--- a/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
@@ -50,7 +50,7 @@ div
         - if !question.leaf?
           = render "admin/loans/questionnaires/progress", object: response, display_pct: true
         - if policy(@loan).update?
-          a.edit-action.view-element(
+          a.edit-action(
             href="javascript:void(0)"
             aria-label="#{t("questions.edit_all")}"
           )

--- a/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_group.html.slim
@@ -49,7 +49,7 @@ div
               = question.full_number_and_label
         - if !question.leaf?
           = render "admin/loans/questionnaires/progress", object: response, display_pct: true
-        - if policy(@loan).update? && @response_set.persisted?
+        - if policy(@loan).update?
           a.edit-action.view-element(
             href="javascript:void(0)"
             aria-label="#{t("questions.edit_all")}"


### PR DESCRIPTION
BEFORE: going into biz planning on a new loan, the form is already in edit mode, and you can't see the pencil icons to go into edit mode, OR see cancel to exit edit mode. 

AFTER: biz planning forms start in show mode. 