### PR TITLE
11675 fix edit bar outline collaps conflict

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -110,7 +110,7 @@ linters:
 
   NestingDepth:
     enabled: true
-    max_depth: 4
+    max_depth: 5
     ignore_parent_selectors: false
 
   PlaceholderInExtend:

--- a/app/assets/javascripts/admin/expander.coffee
+++ b/app/assets/javascripts/admin/expander.coffee
@@ -30,7 +30,7 @@ class MS.Views.Expander extends Backbone.View
 
     # Hide the 'expand' control and show the 'hide' control.
     @$("[data-hides='#{targetName}']").show()
-    @$(e.currentTarget).hide()
+    $link.hide()
 
     # If [data-expand-all] and [data-hide-all] exist in same menu, show [data-expand-all] control.
     $link.siblings('[data-expand-all]').show()
@@ -47,7 +47,7 @@ class MS.Views.Expander extends Backbone.View
     @$("[data-expandable='#{targetName}']").hide('fast')
 
     # Hide the 'hide' control and show the 'expand' control.
-    @$(e.currentTarget).hide()
+    $link.hide()
     @$("[data-expands='#{targetName}']").show()
 
     # If [data-expand-all] and [data-hide-all] exist in same menu, hide these controls.

--- a/app/assets/javascripts/admin/loan_questionnaires_view.coffee
+++ b/app/assets/javascripts/admin/loan_questionnaires_view.coffee
@@ -45,7 +45,7 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
     e.preventDefault
     $('.outline').toggleClass("collapsed expanded")
     $('.questionnaire-wrapper').toggleClass("smaller larger")
-    $('#editBar').toggleClass("smaller larger")
+    $('#edit-bar').toggleClass("smaller larger")
 
 
   # Add a custom event for tree expansion. This event is listened to by LoanChartsView.

--- a/app/assets/javascripts/admin/loan_questionnaires_view.coffee
+++ b/app/assets/javascripts/admin/loan_questionnaires_view.coffee
@@ -45,6 +45,7 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
     e.preventDefault
     $('.outline').toggleClass("collapsed expanded")
     $('.questionnaire-wrapper').toggleClass("smaller larger")
+    $('#editBar').toggleClass("smaller larger")
 
 
   # Add a custom event for tree expansion. This event is listened to by LoanChartsView.

--- a/app/assets/javascripts/admin/loan_questionnaires_view.coffee
+++ b/app/assets/javascripts/admin/loan_questionnaires_view.coffee
@@ -33,11 +33,19 @@ class MS.Views.LoanQuestionnairesView extends Backbone.View
     'click a.deep-link': 'scrollElementToView'
     'change input': 'formUpdated'
     'click .help-block .expansion-control': 'toggleExpansion'
+    'click .outline-expansion-control': 'toggleOutlineExpansion'
+
 
   toggleExpansion: (e) ->
     e.preventDefault
     target = @$(e.currentTarget)
     @$(target.parent()).toggleClass("collapsed expanded")
+
+  toggleOutlineExpansion: (e) ->
+    e.preventDefault
+    $('.outline').toggleClass("collapsed expanded")
+    $('.questionnaire-wrapper').toggleClass("smaller larger")
+
 
   # Add a custom event for tree expansion. This event is listened to by LoanChartsView.
   notifyExpandListeners: (e) ->

--- a/app/assets/stylesheets/admin/_variables.scss
+++ b/app/assets/stylesheets/admin/_variables.scss
@@ -1,5 +1,6 @@
 // Common variables
 $content-wrapper-padding: 20px;
+$tab-pane-padding: 1em;
 $app-fonts: 'Open Sans', sans-serif;
 $q-outline-collapsed-width: 30px;
 $q-outline-expanded-width: 250px;

--- a/app/assets/stylesheets/admin/_variables.scss
+++ b/app/assets/stylesheets/admin/_variables.scss
@@ -1,3 +1,5 @@
 // Common variables
 $content-wrapper-padding: 20px;
 $app-fonts: 'Open Sans', sans-serif;
+$q-outline-collapsed-width: 30px;
+$q-outline-expanded-width: 250px;

--- a/app/assets/stylesheets/admin/loans/_questionnaires.scss
+++ b/app/assets/stylesheets/admin/loans/_questionnaires.scss
@@ -194,35 +194,6 @@ section.questionnaires {
     }
   }
 
-  .form-element.actions#editBar {
-    // When position is fixed, the entire webpage/viewport is the parent element
-    position: fixed;
-    bottom: 0;
-    display: block;
-    padding: 1em;
-    // Use built-in Sass function and color fallback
-    background: $gray2;
-    background: rgba($gray2, 0.7);
-    text-align: right;
-
-    $questionnaire-actions-offset: 2 * $content-wrapper-padding;
-    // width: calc(100% - #{$questionnaire-actions-offset});
-    //
-    // @media (min-width: 768px) {
-    //   width: calc(100% - (#{$questionnaire-actions-offset}));
-    // }
-
-    a {
-      float: none;
-    }
-    &.larger {
-      width: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3) - #{$q-outline-collapsed-width});
-    }
-    &.smaller {
-      width: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3) - #{$q-outline-expanded-width});
-    }
-  }
-
   .not-applicable {
     font-style: italic;
 

--- a/app/assets/stylesheets/admin/loans/_questionnaires.scss
+++ b/app/assets/stylesheets/admin/loans/_questionnaires.scss
@@ -194,7 +194,7 @@ section.questionnaires {
     }
   }
 
-  .form-element.actions {
+  .form-element.actions#editBar {
     // When position is fixed, the entire webpage/viewport is the parent element
     position: fixed;
     bottom: 0;
@@ -207,14 +207,20 @@ section.questionnaires {
     text-align: right;
 
     $questionnaire-actions-offset: 2 * $content-wrapper-padding;
-    width: calc(100% - #{$questionnaire-actions-offset});
-
-    @media (min-width: 768px) {
-      width: calc(100% - (#{$questionnaire-actions-offset}));
-    }
+    // width: calc(100% - #{$questionnaire-actions-offset});
+    //
+    // @media (min-width: 768px) {
+    //   width: calc(100% - (#{$questionnaire-actions-offset}));
+    // }
 
     a {
       float: none;
+    }
+    &.larger {
+      width: calc(100% - (#{$content-wrapper-padding}) - #{$q-outline-collapsed-width});
+    }
+    &.smaller {
+      width: calc(100% - (#{$content-wrapper-padding}) - #{$q-outline-expanded-width});
     }
   }
 

--- a/app/assets/stylesheets/admin/loans/_questionnaires.scss
+++ b/app/assets/stylesheets/admin/loans/_questionnaires.scss
@@ -199,7 +199,6 @@ section.questionnaires {
     position: fixed;
     bottom: 0;
     display: block;
-    margin: 0 0 $content-wrapper-padding;
     padding: 1em;
     // Use built-in Sass function and color fallback
     background: $gray2;
@@ -217,10 +216,10 @@ section.questionnaires {
       float: none;
     }
     &.larger {
-      width: calc(100% - (#{$content-wrapper-padding}) - #{$q-outline-collapsed-width});
+      width: calc(100% - (#{$content-wrapper-padding})*4 - #{$q-outline-collapsed-width});
     }
     &.smaller {
-      width: calc(100% - (#{$content-wrapper-padding}) - #{$q-outline-expanded-width});
+      width: calc(100% - (#{$content-wrapper-padding})*4 - #{$q-outline-expanded-width});
     }
   }
 

--- a/app/assets/stylesheets/admin/loans/_questionnaires.scss
+++ b/app/assets/stylesheets/admin/loans/_questionnaires.scss
@@ -216,10 +216,10 @@ section.questionnaires {
       float: none;
     }
     &.larger {
-      width: calc(100% - (#{$content-wrapper-padding})*4 - #{$q-outline-collapsed-width});
+      width: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3) - #{$q-outline-collapsed-width});
     }
     &.smaller {
-      width: calc(100% - (#{$content-wrapper-padding})*4 - #{$q-outline-expanded-width});
+      width: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3) - #{$q-outline-expanded-width});
     }
   }
 

--- a/app/assets/stylesheets/admin/loans/_tabs.scss
+++ b/app/assets/stylesheets/admin/loans/_tabs.scss
@@ -6,7 +6,7 @@
 }
 
 .tab-pane {
-  padding: 1em;
+  padding: $tab-pane-padding;
 
   &.active {
     background: $background-gray;

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -44,12 +44,12 @@
     }
     .questionnaire-wrapper {
       display: inline-block;
-      margin-left: 10px;
+      margin-left: $tab-pane-padding;
       &.larger {
-        width: calc(100% - (#{$content-wrapper-padding}) - #{$q-outline-collapsed-width});
+        width: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3) - #{$q-outline-collapsed-width});
       }
       &.smaller {
-        width: calc(100% - (#{$content-wrapper-padding}) - #{$q-outline-expanded-width});
+        width: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3) - #{$q-outline-expanded-width});
       }
     }
   }

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -33,7 +33,7 @@
   .row {
     .outline {
       display: inline-block;
-      min-height: 300px;
+      min-height: calc(50vw);
       vertical-align: top;
       &.collapsed {
         width: $q-outline-collapsed-width;
@@ -62,8 +62,8 @@
         display: block;
         padding: 1em;
         // Use built-in Sass function and color fallback
-        background: magenta; //#$gray2;
-        background: magenta;//rgba($gray2, 0.7);
+        background: $gray2;
+        background: rgba($gray2, 0.7);
         text-align: right;
 
         a {

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -31,16 +31,26 @@
     }
   }
   .row {
-    display: grid;
-    grid-template-columns: auto minmax(70%, 100%);
-    gap: 10px;
     .outline {
-      grid-row: 1 / 1;
-      grid-column: 1 / 2;
+      display: inline-block;
+      min-height: 300px;
+      vertical-align: top;
+      &.collapsed {
+        width: $q-outline-collapsed-width;
+      }
+      &.expanded {
+        width: $q-outline-expanded-width;
+      }
     }
     .questionnaire-wrapper {
-      grid-row: 1 / 1;
-      grid-column: 2 / 2;
+      display: inline-block;
+      margin-left: 10px;
+      &.larger {
+        width: calc(100% - (#{$content-wrapper-padding}) - #{$q-outline-collapsed-width});
+      }
+      &.smaller {
+        width: calc(100% - (#{$content-wrapper-padding}) - #{$q-outline-expanded-width});
+      }
     }
   }
 }

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -48,25 +48,28 @@
 
     .questionnaire-wrapper {
       // below variable used to sync the dynamic size of fixed-position edit bar and the questionnaire it overlays
-      $questionnaire-width-adjustment: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3)) ;
+      $questionnaire-width-adjustment: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3));
       display: inline-block;
       margin-left: $tab-pane-padding;
+
       &.larger {
         width: calc(#{$questionnaire-width-adjustment} - #{$q-outline-collapsed-width});
       }
+
       &.smaller {
         width: calc(#{$questionnaire-width-adjustment} - #{$q-outline-expanded-width});
       }
 
-      .form-element.actions#editBar {
+      .form-element.actions#edit-bar {
         // When position is fixed, the entire webpage/viewport is the parent element
-        position: fixed;
+        background: $gray2;
+        background: rgba($gray2, 0.7);
         bottom: 0;
         display: block;
         padding: 1em;
+        position: fixed;
         // Use built-in Sass function and color fallback
-        background: $gray2;
-        background: rgba($gray2, 0.7);
+
         text-align: right;
 
         a {

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -44,6 +44,7 @@
     }
 
     .questionnaire-wrapper {
+      // below variable used to sync the dynamic size of fixed-position edit bar and the questionnaire it overlays
       $questionnaire-width-adjustment: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3)) ;
       display: inline-block;
       margin-left: $tab-pane-padding;

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -42,14 +42,38 @@
         width: $q-outline-expanded-width;
       }
     }
+
     .questionnaire-wrapper {
+      $questionnaire-width-adjustment: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3)) ;
       display: inline-block;
       margin-left: $tab-pane-padding;
       &.larger {
-        width: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3) - #{$q-outline-collapsed-width});
+        width: calc(#{$questionnaire-width-adjustment} - #{$q-outline-collapsed-width});
       }
       &.smaller {
-        width: calc(100vw - (#{$content-wrapper-padding} * 3) - (#{$tab-pane-padding} * 3) - #{$q-outline-expanded-width});
+        width: calc(#{$questionnaire-width-adjustment} - #{$q-outline-expanded-width});
+      }
+
+      .form-element.actions#editBar {
+        // When position is fixed, the entire webpage/viewport is the parent element
+        position: fixed;
+        bottom: 0;
+        display: block;
+        padding: 1em;
+        // Use built-in Sass function and color fallback
+        background: magenta; //#$gray2;
+        background: magenta;//rgba($gray2, 0.7);
+        text-align: right;
+
+        a {
+          float: none;
+        }
+        &.larger {
+          width: calc(#{$questionnaire-width-adjustment} - #{$q-outline-collapsed-width});
+        }
+        &.smaller {
+          width: calc(#{$questionnaire-width-adjustment} - #{$q-outline-expanded-width});
+        }
       }
     }
   }

--- a/app/assets/stylesheets/admin/questions/_questions.scss
+++ b/app/assets/stylesheets/admin/questions/_questions.scss
@@ -30,14 +30,17 @@
       padding-top: 10px;
     }
   }
+
   .row {
     .outline {
       display: inline-block;
       min-height: calc(50vw);
       vertical-align: top;
+
       &.collapsed {
         width: $q-outline-collapsed-width;
       }
+
       &.expanded {
         width: $q-outline-expanded-width;
       }
@@ -69,9 +72,11 @@
         a {
           float: none;
         }
+
         &.larger {
           width: calc(#{$questionnaire-width-adjustment} - #{$q-outline-collapsed-width});
         }
+
         &.smaller {
           width: calc(#{$questionnaire-width-adjustment} - #{$q-outline-expanded-width});
         }

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -77,17 +77,3 @@ javascript:
       }
     });
   });
-
-  $(function() {
-    var $editBar = $("#editBar")
-        $window    = $(window)
-    resizeEditBar = function () {
-      $editBar.css('width', $editBar.parent().width())
-    }
-    resizeEditBar()
-    $window.resize(function() {
-      console.log("resized! parent is this wide:")
-      console.log($editBar.parent().width())
-      $editBar.css('width', $editBar.parent().width())
-    });
-  });

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -27,7 +27,7 @@ section.questionnaires
       h2 = t("loan.#{@attrib}")
       div.container
         div.row
-          div.outline
+          div.outline.collapsed
             div.outline-expansion-control.small.hider
               = fa_icon("chevron-left", data: {hides: "outline-container"})
             h5.outline-expansion-control.expander
@@ -35,7 +35,7 @@ section.questionnaires
             div.outline-container data-expandable="outline-container"
               h4 = t("admin.loans.questions.outline.header")
               = render "admin/loans/questionnaires/questionnaire_outline", questions: @root.children, depth: 0, parent: @root
-          div.questionnaire-wrapper
+          div.questionnaire-wrapper.larger
             = render partial: "admin/loans/questionnaires/questionnaire_form",
                      locals: {response_set: @response_set, attrib: @attrib}
 

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -59,7 +59,7 @@ javascript:
     var $sidebar   = $(".outline"),
         $window    = $(window),
         topPadding = 15;
-        originalYAdjustment = $sidebar.offset().top - $(".navbar-fixed-top").height() - topPadding
+        originalYAdjustment = $sidebar.offset().top - $("#site-header").height() - $("#site-menu").height()- topPadding
     $window.scroll(function() {
       offset     = $sidebar.offset()
       $outlineHeight = $(".outline-container").height()

--- a/app/views/admin/loans/_questions.html.slim
+++ b/app/views/admin/loans/_questions.html.slim
@@ -54,26 +54,3 @@ javascript:
       locale: "#{I18n.locale}"
     });
   });
-
-  $(function() {
-    var $sidebar   = $(".outline"),
-        $window    = $(window),
-        topPadding = 15;
-        originalYAdjustment = $sidebar.offset().top - $("#site-header").height() - $("#site-menu").height()- topPadding
-    $window.scroll(function() {
-      offset     = $sidebar.offset()
-      $outlineHeight = $(".outline-container").height()
-      $containerHeight = $("#questions").height()
-      if ($window.scrollTop() > originalYAdjustment){
-        if ($outlineHeight > $window.innerHeight()){
-          percentage = $window.scrollTop()/$containerHeight
-          adjustment = Math.max($outlineHeight * percentage, originalYAdjustment)
-          $sidebar.css('margin-top', $window.scrollTop() - adjustment)
-        }else{
-          $sidebar.css('margin-top', $window.scrollTop() - originalYAdjustment)
-        }
-      } else {
-        $sidebar.css('margin-top',"7px")
-      }
-    });
-  });

--- a/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
@@ -40,7 +40,7 @@
     - unless @print_view
       .jqtree data-data=@questions_json class=attrib id="jqtree"
 
-    .actions.form-element.larger#editBar
+    .actions.form-element.larger#edit-bar
       h3.now-editing.custom_dark_accent
         = fa_icon "exclamation-circle"
         = t("questions.currently_editing")

--- a/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
+++ b/app/views/admin/loans/questionnaires/_questionnaire_form.html.slim
@@ -40,7 +40,7 @@
     - unless @print_view
       .jqtree data-data=@questions_json class=attrib id="jqtree"
 
-    .actions.form-element#editBar
+    .actions.form-element.larger#editBar
       h3.now-editing.custom_dark_accent
         = fa_icon "exclamation-circle"
         = t("questions.currently_editing")

--- a/spec/features/admin/questionnaire_spec.rb
+++ b/spec/features/admin/questionnaire_spec.rb
@@ -22,7 +22,7 @@ feature 'questionnaire', js: true do
       expect(page).to have_content("Now editing")
 
       # cancel button is visible in edit mode
-      first("#editBar .cancel-edit").click
+      first("#edit-bar .cancel-edit").click
       expect(page).not_to have_content("Now editing")
 
       # save changes button is visible in edit mode


### PR DESCRIPTION
Reworks css & js so that in questionnaire, outline collapsing and the dynamic width of fixed-position edit bar work together ok. 
<img width="1640" alt="Screen Shot 2021-04-02 at 5 22 26 PM" src="https://user-images.githubusercontent.com/4730344/113455259-281adc00-93d8-11eb-8a82-07f3659bcd5b.png">
<img width="1637" alt="Screen Shot 2021-04-02 at 5 22 16 PM" src="https://user-images.githubusercontent.com/4730344/113455264-2a7d3600-93d8-11eb-8aee-ef0524d6c1c3.png">

