### PR TITLE
10317: restore txn date order to txns grid

### DIFF
--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -190,7 +190,7 @@ module Admin
       @transactions = ::Accounting::Transaction.where(project: @loan)
       @transactions.includes(:account, :project, :currency, :line_items).standard_order
       @enable_export_to_csv = true
-      @transactions_grid = initialize_grid(@transactions, enable_export_to_csv: @enable_export_to_csv,
+      @transactions_grid = initialize_grid(@transactions, order: 'accounting_transactions.txn_date', enable_export_to_csv: @enable_export_to_csv,
                                                           per_page: 100, name: 'transactions')
       export_grid_if_requested('transactions': 'admin/accounting/transactions/transactions_grid_definition')
       show_reasons_if_read_only


### PR DESCRIPTION
hotfix on staging, because this is blocking Zahuna and Eden from testing. When we removed the 'initialize_transactions_grid' in 11669 we lost the sort order by txn date, and I ddin't test for that in qa. This just restores it. 