### PR TITLE
11760 admin cant see problem loan txns

### DIFF
--- a/app/controllers/admin/accounting/problem_loan_transactions_controller.rb
+++ b/app/controllers/admin/accounting/problem_loan_transactions_controller.rb
@@ -14,8 +14,8 @@ module Admin
       end
 
       def show
-        authorize :'accounting/problem_loan_transaction', :show?
         @plt = ::Accounting::ProblemLoanTransaction.find(params[:id])
+        authorize @plt
       end
     end
   end

--- a/app/models/accounting/problem_loan_transaction.rb
+++ b/app/models/accounting/problem_loan_transaction.rb
@@ -30,6 +30,7 @@ module Accounting
     delegate :id, :display_name, to: :loan, prefix: :loan
     delegate :txn_date, :qb_id, :amount, :change_in_interest, :change_in_principal, :currency, :quickbooks_data, to: :accounting_transaction
     delegate :id, :description, to: :accounting_transaction, prefix: :txn
+    delegate :division, to: :loan
 
     def associated_loan_ids
       self.class.where(

--- a/app/policies/accounting/problem_loan_transaction_policy.rb
+++ b/app/policies/accounting/problem_loan_transaction_policy.rb
@@ -1,2 +1,24 @@
 class Accounting::ProblemLoanTransactionPolicy < ApplicationPolicy
+  # TODO if we move forward with division-based qb connections, PLTs should belong to
+  # a qb division as well as a loan (and PLTs will likely need more refactoring)
+  # For now, only root div admins
+  def index?
+    division_admin(division: Division.root)
+  end
+
+  def show?
+    division_admin(division: Division.root)
+  end
+
+  def create?
+    false
+  end
+
+  def update?
+    false
+  end
+
+  def destroy?
+    false
+  end
 end

--- a/app/policies/accounting/problem_loan_transaction_policy.rb
+++ b/app/policies/accounting/problem_loan_transaction_policy.rb
@@ -1,2 +1,2 @@
-class Accounting::ProblemLoanTransactionPolicy < Accounting::TransactionPolicy
+class Accounting::ProblemLoanTransactionPolicy < ApplicationPolicy
 end

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -218,7 +218,7 @@ en:
         change_in_interest: "Change in Interest"
         change_in_principal: "Change in Principal"
         check_number: "Check Number"
-        customer: "QuickBooks Customer"
+        customer: "Coop"
         description: "Description"
         interest_balance: "Interest Balance"
         loan_transaction_type_value: "Type of Transaction"

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -218,7 +218,7 @@ en:
         change_in_interest: "Change in Interest"
         change_in_principal: "Change in Principal"
         check_number: "Check Number"
-        customer: "Coop"
+        customer: "QuickBooks Customer"
         description: "Description"
         interest_balance: "Interest Balance"
         loan_transaction_type_value: "Type of Transaction"

--- a/spec/policies/accounting/problem_loan_transaction_policy_spec.rb
+++ b/spec/policies/accounting/problem_loan_transaction_policy_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Accounting::ProblemLoanTransactionPolicy do
+  let(:parent_division) { create(:division, :with_accounts, qb_read_only: false) }
+  let(:division) { create(:division, :with_qb_dept, parent: parent_division) }
+  let(:loan_trait) { :active }
+  let(:loan_txn_mode) { Loan::TXN_MODE_AUTO }
+  let(:loan) { create(:loan, loan_trait, division: division, txn_handling_mode: loan_txn_mode) }
+  let(:txn) { Accounting::Transaction.new(project: loan) }
+  let(:described_plt) { Accounting::ProblemLoanTransaction.new(project_id: loan.id, accounting_transaction_id: txn.id) }
+  subject(:policy) { described_class.new(user, described_plt) }
+
+  context 'with non-admin' do
+    let(:user) { create(:user) }
+    forbid_all
+  end
+
+  context 'with admin of unrelated division' do
+    let(:user) { create(:user, :admin, division: create(:division)) }
+    forbid_all
+  end
+
+  context 'with admin of same non-root division' do
+    let(:user) { create(:user, :admin, division: division) }
+    forbid_all
+  end
+
+  context 'with root admin' do
+    let(:user) { create_admin(root_division) }
+    forbid_all_but_read
+  end
+
+end

--- a/spec/policies/accounting/problem_loan_transaction_policy_spec.rb
+++ b/spec/policies/accounting/problem_loan_transaction_policy_spec.rb
@@ -31,5 +31,4 @@ describe Accounting::ProblemLoanTransactionPolicy do
     let(:user) { create_admin(root_division) }
     forbid_all_but_read
   end
-
 end


### PR DESCRIPTION
The transaction policy refactor had a regression where no one could see problem loan transaction information. Problem loan transactions are not a subclass of transactions. PLTs reports errors madeline had processing txns imported from QB. The primary audience for these are us (the development team), and highly skilled madeline admins (e.g. Eden and Zahuna). Making them useful to other people would need design work.  An earlier commit of this branch is deployed on staging so that Eden & Zahuna could test on Thurs & Friday. This branch is a small improvement, with root division admins able to see  spec coverage on the separate problem loan transaction policy. In this version, root admins can see the index and show for problem loan transactions and that is now documented in the specs. 

For accounting, we should show non root admins an alternate version of the <img width="1204" alt="Screen Shot 2021-04-30 at 8 20 42 PM" src="https://user-images.githubusercontent.com/4730344/116765147-d6269f80-a9f1-11eb-9b04-7682b4206f2c.png"> "There are n warnings associated with transactions for this loan. Your loan balances may not be correct. Please review the transactions with warnings, and only proceed once you have confirmed they are correct. " warning and similar error. I would love to chat w Tom or Melody about the best way to do that in the loan controller. 

For division-based accounting we should revisit problem loan transactions. 

Note: if this branch is not merged before release, Zahuna and Eden will experience a regression on staging where they cannot click through to transaction warnings & errors. 




