### PR TITLE
11781 error in qb ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem "chronic" # For parsing human readable dates
 gem "exception_notification" # Send email on errors
 gem "goldiloader" # Eager loading
 gem "gon" # Passing controller data to JS
-gem "quickbooks-ruby"
+gem "quickbooks-ruby", "= 1.0.10"
 gem "remotipart", "~> 1.2" # File uploads for remote: true forms
 gem 'sassc-rails'
 gem "scout_apm"

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem "chronic" # For parsing human readable dates
 gem "exception_notification" # Send email on errors
 gem "goldiloader" # Eager loading
 gem "gon" # Passing controller data to JS
+gem "nokogiri", "= 1.10.10"
 gem "quickbooks-ruby", "= 1.0.10"
 gem "remotipart", "~> 1.2" # File uploads for remote: true forms
 gem 'sassc-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.8)
-    connection_pool (2.2.2)
+    connection_pool (2.2.5)
     crass (1.0.6)
     daemons (1.2.6)
     database_cleaner (1.7.0)
@@ -183,7 +183,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.9.1)
       i18n (>= 0.7)
-    faraday (0.17.0)
+    faraday (0.17.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.15.0)
     fix-db-schema-conflicts (3.0.2)
@@ -257,7 +257,7 @@ GEM
       railties (>= 3.2.16)
     json (2.3.1)
     jsonapi-renderer (0.2.0)
-    jwt (2.2.1)
+    jwt (2.2.3)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -283,7 +283,7 @@ GEM
     mime-types-data (3.2020.0512)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.4)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
@@ -296,13 +296,13 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
     nio4r (2.5.7)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oauth (0.4.7)
-    oauth2 (1.4.2)
+    oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
@@ -333,13 +333,13 @@ GEM
       activesupport (>= 3.0.0)
     pundit-matchers (1.6.0)
       rspec-rails (>= 3.0.0)
-    quickbooks-ruby (1.0.1)
-      activemodel
+    quickbooks-ruby (1.0.10)
+      activemodel (> 4.0)
       multipart-post
       nokogiri
-      oauth (~> 0.4.7)
       oauth2 (~> 1.4)
-      roxml (= 4.0.0)
+      roxml (~> 4.0)
+    racc (1.5.2)
     rack (2.2.3)
     rack-livereload (0.3.17)
       rack
@@ -402,7 +402,7 @@ GEM
     route_translator (5.6.4)
       actionpack (>= 5.0.0.1, < 6)
       activesupport (>= 5.0.0.1, < 6)
-    roxml (4.0.0)
+    roxml (4.1.1)
       activesupport (>= 4.0)
       nokogiri (>= 1.3.3)
     rspec-core (3.8.0)
@@ -586,7 +586,7 @@ DEPENDENCIES
   puma
   pundit
   pundit-matchers
-  quickbooks-ruby
+  quickbooks-ruby (= 1.0.10)
   rack-livereload
   rails (~> 5.1, >= 5.1.4)
   rails-backbone

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
     mime-types-data (3.2020.0512)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.1)
+    mini_portile2 (2.4.0)
     minitest (5.14.4)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
@@ -296,9 +296,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
     nio4r (2.5.7)
-    nokogiri (1.11.3)
-      mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -339,7 +338,6 @@ GEM
       nokogiri
       oauth2 (~> 1.4)
       roxml (~> 4.0)
-    racc (1.5.2)
     rack (2.2.3)
     rack-livereload (0.3.17)
       rack
@@ -578,6 +576,7 @@ DEPENDENCIES
   mini_magick (>= 4.9.4)
   momentjs-rails
   mysql2
+  nokogiri (= 1.10.10)
   pg (~> 0.15, < 0.21.0)
   poltergeist (~> 1.0)
   pry (= 0.10.4)

--- a/app/views/admin/project_logs/_log.html.slim
+++ b/app/views/admin/project_logs/_log.html.slim
@@ -52,7 +52,7 @@
   - if log.summary
     .summary
       h5.sr-only = t('common.summary')
-      span = strip_tags(log.summary)
+      span = strip_tags(log.summary.to_s)
 
   - if log.has_more? && @context != 'dashboard'
     div

--- a/app/views/admin/project_logs/_log.html.slim
+++ b/app/views/admin/project_logs/_log.html.slim
@@ -52,7 +52,7 @@
   - if log.summary
     .summary
       h5.sr-only = t('common.summary')
-      span = strip_tags(log.summary.to_s)
+      span = strip_tags(log.summary)
 
   - if log.has_more? && @context != 'dashboard'
     div


### PR DESCRIPTION
We needed to upgrade quickbooks_ruby, which was breaking on certain txns where older version of quickbooks_ruby was erring on a call to BigDecimal.new in dependency, roxml. (see https://github.com/Empact/roxml/releases/tag/v4.1.0) This branch currently on staging so I could continue looking into issues with that loan (3293).