### PR TITLE
11799 notify on bg error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,6 @@ export QB_SANDBOX_OAUTH2_CLIENT_SECRET=xxx
 # Set this to 1 or 0 for manual override.
 export QB_SANDBOX_MODE=1
 
-export SENTRY_DSN=
 export SCOUT_KEY=
 
 # S3-Compatible Storage Settings - see fog/carrierwave documentation for example values

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ gem "quickbooks-ruby", "= 1.0.10"
 gem "remotipart", "~> 1.2" # File uploads for remote: true forms
 gem "sassc-rails"
 gem "scout_apm"
-gem "sentry-raven"
 gem "simple_form"
 gem "sprockets", "~> 3.7.2"
 gem "summernote-rails", "~> 0.8.10.0" # Text editor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,8 +183,15 @@ GEM
       railties (>= 3.0.0)
     faker (1.9.1)
       i18n (>= 0.7)
-    faraday (0.17.4)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-excon (1.1.0)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     ffi (1.15.0)
     fix-db-schema-conflicts (3.0.2)
       rubocop (>= 0.38.0)
@@ -441,6 +448,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.0)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.4)
     ruby_dep (1.5.0)
     rubyzip (1.3.0)
     sassc (2.0.1)
@@ -463,8 +471,6 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    sentry-raven (2.13.0)
-      faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
     sidekiq (5.2.6)
       connection_pool (~> 2.2, >= 2.2.2)
@@ -611,7 +617,6 @@ DEPENDENCIES
   seed_dump
   select2-rails
   selenium-webdriver (~> 2.0)
-  sentry-raven
   sidekiq
   simple_form
   simplecov

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,8 +17,6 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-  before_action :set_raven_context
-
   def admin_controller?
     false
   end
@@ -72,10 +70,5 @@ class ApplicationController < ActionController::Base
     if lang_header = request.env['HTTP_ACCEPT_LANGUAGE']
       lang_header.scan(/^[a-z]{2}/).first.to_sym
     end
-  end
-
-  def set_raven_context
-    Raven.user_context(id: current_user&.id, email: current_user&.email) # or anything else in session
-    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,8 +1,16 @@
 class ApplicationJob < ActiveJob::Base
   queue_as :default
 
-  rescue_from(StandardError) do |exception|
-    ExceptionNotifier.notify_exception(exception, data: {job: to_yaml})
-    raise exception
+  rescue_from(StandardError) do |error|
+    notify_of_error(error)
+
+    # Re-raising the error so that the job system will detect it and act accordingly.
+    raise error
+  end
+
+  protected
+
+  def notify_of_error(error)
+    ExceptionNotifier.notify_exception(error, data: {job: to_yaml})
   end
 end

--- a/app/jobs/data_export_task_job.rb
+++ b/app/jobs/data_export_task_job.rb
@@ -14,7 +14,7 @@ class DataExportTaskJob < TaskJob
   rescue_from(DataExportError) do |error|
     task_for_job(self).set_activity_message("finished_with_custom_error_data")
     task_for_job(self).fail!
-    ExceptionNotifier.notify_exception(error, data: {job: to_yaml})
+    notify_of_error(error)
     raise error
   end
 end

--- a/app/jobs/fetch_quickbooks_changes_job.rb
+++ b/app/jobs/fetch_quickbooks_changes_job.rb
@@ -1,61 +1,9 @@
-class FetchQuickbooksChangesJob < TaskJob
-  def perform(_job_params)
-    task = task_for_job(self)
-    errors_by_loan = []
-    divisions = Division.qb_accessible_divisions
-    updater = Accounting::QB::Updater.new
-    updater.qb_sync_for_loan_update
+class FetchQuickbooksChangesJob < QuickbooksUpdateJob
+  protected
 
-    loans = divisions.map { |i| i.loans.changed_since(updater.qb_connection.last_updated_at).active }.flatten.compact
-    task.set_activity_message("syncing_with_quickbooks")
-    loans.each_with_index do |loan, index|
-      task.set_activity_message("updating_loans", so_far: (index), total: loans.count)
-      begin
-        updater.update_loan(loan)
-      rescue StandardError => error
-        errors_by_loan << {loan_id: loan.id, message: error.message}
-        next
-      end
-    end
-    if errors_by_loan.empty?
-      task_for_job(self).set_activity_message("completed")
-    else
-      handle_child_errors(task, errors_by_loan)
-    end
-  end
-
-  rescue_from(Accounting::QB::NotConnectedError) do |error|
-    task_for_job(self).set_activity_message("error_quickbooks_not_connected")
-    record_failure_and_raise_error(error)
-  end
-
-  rescue_from(Accounting::QB::DataResetRequiredError) do |error|
-    task_for_job(self).set_activity_message("error_data_reset_required")
-    record_failure_and_raise_error(error)
-  end
-
-  rescue_from(Accounting::QB::AccountsNotSelectedError) do |error|
-    task_for_job(self).set_activity_message("error_quickbooks_accounts_not_selected")
-    record_failure_and_raise_error(error)
-  end
-
-  rescue_from(TaskHasChildErrorsError) do |error|
-    task_for_job(self).set_activity_message("finished_with_custom_error_data")
-    record_failure_and_raise_error(error)
-  end
-
-  private
-
-  def handle_child_errors(task, errors_by_loan)
-    unless errors_by_loan.empty?
-      task.update(custom_error_data: errors_by_loan)
-      raise TaskHasChildErrorsError.new("Some loans failed to update.")
-    end
-  end
-
-  def record_failure_and_raise_error(error)
-    task_for_job(self).fail!
-    notify_of_error(error)
-    raise error
+  def loans
+    @loans ||= divisions.map do |division|
+      division.loans.changed_since(updater.qb_connection.last_updated_at).active
+    end.flatten.compact
   end
 end

--- a/app/jobs/fetch_quickbooks_changes_job.rb
+++ b/app/jobs/fetch_quickbooks_changes_job.rb
@@ -55,7 +55,7 @@ class FetchQuickbooksChangesJob < TaskJob
 
   def record_failure_and_raise_error(error)
     task_for_job(self).fail!
-    ExceptionNotifier.notify_exception(error, data: {job: to_yaml})
+    notify_of_error(error)
     raise error
   end
 end

--- a/app/jobs/quickbooks_update_job.rb
+++ b/app/jobs/quickbooks_update_job.rb
@@ -6,7 +6,7 @@ class QuickbooksUpdateJob < TaskJob
     updater.qb_sync_for_loan_update
     task.set_activity_message("syncing_with_quickbooks")
     loans.each_with_index do |loan, index|
-      task.set_activity_message("dupdating_loans", so_far: (index), total: loans.count)
+      task.set_activity_message("updating_loans", so_far: (index), total: loans.count)
       begin
         updater.update_loan(loan)
       rescue StandardError => e

--- a/app/jobs/quickbooks_update_job.rb
+++ b/app/jobs/quickbooks_update_job.rb
@@ -1,0 +1,64 @@
+class QuickbooksUpdateJob < TaskJob
+  def perform(_job_params)
+    task = task_for_job(self)
+    errors_by_loan = []
+    updater = Accounting::QB::Updater.new
+    updater.qb_sync_for_loan_update
+    task.set_activity_message("syncing_with_quickbooks")
+    loans.each_with_index do |loan, index|
+      task.set_activity_message("dupdating_loans", so_far: (index), total: loans.count)
+      begin
+        updater.update_loan(loan)
+      rescue StandardError => error
+        errors_by_loan << {loan_id: loan.id, message: error.message}
+        next
+      end
+    end
+    if errors_by_loan.empty?
+      task_for_job(self).set_activity_message("completed")
+    else
+      handle_child_errors(task, errors_by_loan)
+    end
+  end
+
+  rescue_from(Accounting::QB::NotConnectedError) do |error|
+    task_for_job(self).set_activity_message("error_quickbooks_not_connected")
+    record_failure_and_raise_error(error)
+  end
+
+  rescue_from(Accounting::QB::DataResetRequiredError) do |error|
+    task_for_job(self).set_activity_message("error_data_reset_required")
+    record_failure_and_raise_error(error)
+  end
+
+  rescue_from(Accounting::QB::AccountsNotSelectedError) do |error|
+    task_for_job(self).set_activity_message("error_quickbooks_accounts_not_selected")
+    record_failure_and_raise_error(error)
+  end
+
+  rescue_from(TaskHasChildErrorsError) do |error|
+    task_for_job(self).set_activity_message("finished_with_custom_error_data")
+    record_failure_and_raise_error(error)
+  end
+
+  protected
+
+  def divisions
+    @divisions ||= Division.qb_accessible_divisions
+  end
+
+  private
+
+  def handle_child_errors(task, errors_by_loan)
+    unless errors_by_loan.empty?
+      task.update(custom_error_data: errors_by_loan)
+      raise TaskHasChildErrorsError.new("Some loans failed to update.")
+    end
+  end
+
+  def record_failure_and_raise_error(error)
+    task_for_job(self).fail!
+    notify_of_error(error)
+    raise error
+  end
+end

--- a/app/jobs/update_all_loans_job.rb
+++ b/app/jobs/update_all_loans_job.rb
@@ -55,7 +55,7 @@ class UpdateAllLoansJob < TaskJob
 
   def record_failure_and_raise_error(error)
     task_for_job(self).fail!
-    ExceptionNotifier.notify_exception(error, data: {job: to_yaml})
+    notify_of_error(error)
     raise error
   end
 end

--- a/app/jobs/update_all_loans_job.rb
+++ b/app/jobs/update_all_loans_job.rb
@@ -1,61 +1,7 @@
-class UpdateAllLoansJob < TaskJob
-  def perform(_job_params)
-    task = task_for_job(self)
-    errors_by_loan = []
-    divisions = Division.qb_accessible_divisions
-    updater = Accounting::QB::Updater.new
-    updater.qb_sync_for_loan_update
+class UpdateAllLoansJob < QuickbooksUpdateJob
+  protected
 
-    loans = divisions.map { |i| i.loans }.flatten.compact
-    task.set_activity_message("syncing_with_quickbooks")
-    loans.each_with_index do |loan, index|
-      task.set_activity_message("updating_loans", {so_far: (index), total: loans.count})
-      begin
-        updater.update_loan(loan)
-      rescue StandardError => error
-        errors_by_loan << {loan_id: loan.id, message: error.message}
-        next
-      end
-    end
-    if errors_by_loan.empty?
-      task_for_job(self).set_activity_message("completed")
-    else
-      handle_child_errors(task, errors_by_loan)
-    end
-  end
-
-  rescue_from(Accounting::QB::NotConnectedError) do |error|
-    task_for_job(self).set_activity_message("error_quickbooks_not_connected")
-    record_failure_and_raise_error(error)
-  end
-
-  rescue_from(Accounting::QB::DataResetRequiredError) do |error|
-    task_for_job(self).set_activity_message("error_data_reset_required")
-    record_failure_and_raise_error(error)
-  end
-
-  rescue_from(Accounting::QB::AccountsNotSelectedError) do |error|
-    task_for_job(self).set_activity_message("error_quickbooks_accounts_not_selected")
-    record_failure_and_raise_error(error)
-  end
-
-  rescue_from(TaskHasChildErrorsError) do |error|
-    task_for_job(self).set_activity_message("finished_with_custom_error_data")
-    record_failure_and_raise_error(error)
-  end
-
-  private
-
-  def handle_child_errors(task, errors_by_loan)
-    unless errors_by_loan.empty?
-      task.update(custom_error_data: errors_by_loan)
-      raise TaskHasChildErrorsError.new("Some loans failed to update.")
-    end
-  end
-
-  def record_failure_and_raise_error(error)
-    task_for_job(self).fail!
-    notify_of_error(error)
-    raise error
+  def loans
+    @loans ||= divisions.map(&:loans).flatten.compact
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,10 +51,6 @@ module MadelineSystem
     config.generators do |g|
       g.fixture_replacement :factory_bot, suffix: 'factory'
     end
-
-    Raven.configure do |config|
-      config.dsn = ENV['SENTRY_DSN']
-    end
   end
 
   # This seems to be required for proper rendering of all wice_grid views. (Without, view contents is all html escaped.)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,0 @@
-Raven.configure do |config|
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-end

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -325,6 +325,7 @@ en:
   loading: "Loading..."
   error: "Error"
   error_notification: "We're sorry, but there was an error in processing your request."
+  system_error_notified: "System error. Developers have been notified."
   close: "Close"
   select_prompt: "Select..."
 

--- a/spec/jobs/update_all_loans_job_spec.rb
+++ b/spec/jobs/update_all_loans_job_spec.rb
@@ -21,7 +21,6 @@ describe UpdateAllLoansJob do
   end
 
   context "qb is not connected" do
-
     subject(:task_job) do
       Class.new(described_class) do
         def perform(_task_data, *_args)


### PR DESCRIPTION
NOTE: Best to review this one commit-by-commit to see what actually changed in the job.

* Removed Sentry for now b/c the gem was deprecated, we weren't actually using it in the code properly yet, and I am a bit concerned about the extra complexity it's adding at a time when we are trying to stabilize our error handling flows
* Unified two very similar QB related job classes
* Removed explicit error message from Task UI. For now this means it will always show "system error. devs notified" for all loans in the list. I think we need to rethink the tasks page error display along with the problem loan transactions thing. It could be that in the future that area could hold error information potentially of use to the user that is not related to a particular transaction. So I didn't want to rip it out completely at this point.