### PR TITLE
11809: hide old system txn menu from all but root admins

### DIFF
--- a/app/policies/loan_policy.rb
+++ b/app/policies/loan_policy.rb
@@ -7,6 +7,10 @@ class LoanPolicy < ProjectPolicy
     show?
   end
 
+  def old_system_access?
+    division_admin(division: Division.root)
+  end
+
   class Scope < DivisionOwnedScope
     def resolve
       user ? super : publicly_visible(scope)

--- a/app/views/admin/loans/_details.html.slim
+++ b/app/views/admin/loans/_details.html.slim
@@ -4,7 +4,7 @@ section.loan-fields data-container='details' class=(@loan.valid? ? 'show-view' :
     / Edit
     - if @loan.valid?
       a.edit-action.view-element
-        i.fa.fa-pencil.fa-large> 
+        i.fa.fa-pencil.fa-large>
         = t("loan.edit")
       a.show-action.form-element
         = t("cancel_edit")
@@ -25,16 +25,17 @@ section.loan-fields data-container='details' class=(@loan.valid? ? 'show-view' :
         = t("loan.duplicate")
 
     / Open Transactions - Old System
-    span.dropdown
-      a.dropdown-toggle aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#" role="button"
-        => t('loan.transactions_old')
-        span.caret
-      ul.dropdown-menu.dropdown-menu-right
-        - if @loan.status_value == 'active'
-          li = link_to(t('loan.transaction_new_disbursement'), old_system_new_disbursement_url(loan: @loan), target: '_blank')
-          li = link_to(t('loan.transaction_new_repayment'), old_system_new_repayment_url(loan: @loan), target: '_blank')
-          li.divider role="separator"
-        li = link_to(t('loan.transaction_schedule'), old_system_schedule_url(loan: @loan), target: '_blank')
+    - if policy(@loan).old_system_access?
+      span.dropdown
+        a.dropdown-toggle aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#" role="button"
+          => t('loan.transactions_old')
+          span.caret
+        ul.dropdown-menu.dropdown-menu-right
+          - if @loan.status_value == 'active'
+            li = link_to(t('loan.transaction_new_disbursement'), old_system_new_disbursement_url(loan: @loan), target: '_blank')
+            li = link_to(t('loan.transaction_new_repayment'), old_system_new_repayment_url(loan: @loan), target: '_blank')
+            li.divider role="separator"
+          li = link_to(t('loan.transaction_schedule'), old_system_schedule_url(loan: @loan), target: '_blank')
 
     / Open Loan Memo
     span.dropdown

--- a/spec/features/admin/loan_flow_spec.rb
+++ b/spec/features/admin/loan_flow_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'loan flow' do
+feature "loan flow" do
   let(:division) { create(:division) }
   let(:user) { create_member(division) }
   let!(:loan) { create(:loan, division: division) }
@@ -35,6 +35,7 @@ feature 'loan flow' do
 
       loan.timeline_entries.each do |te|
         next unless te.is_a?(ProjectStep)
+
         if te.is_finalized?
           expect(page).to have_content(te.summary)
         else
@@ -52,6 +53,7 @@ feature 'loan flow' do
 
       loan.timeline_entries.each do |te|
         next unless te.is_a?(ProjectStep)
+
         if te.milestone?
           expect(page).to have_content(te.summary)
         else
@@ -61,26 +63,46 @@ feature 'loan flow' do
     end
   end
 
-  describe 'details' do
-    scenario 'can duplicate', js: true do
+  describe "details" do
+    scenario "can duplicate", js: true do
       visit admin_loan_path(loan)
 
-      accept_confirm { click_on('Duplicate') }
+      accept_confirm { click_on("Duplicate") }
       expect(page).to have_content "Copy of #{loan.display_name}"
+    end
+
+    describe "old system menu" do
+      context "as member" do
+        scenario "old system menu hidden" do
+          visit admin_loan_path(loan)
+          expect(page).not_to have_content("Transactions (old system)")
+        end
+      end
+
+      context "as admin" do
+        let(:division) { Division.root }
+        let(:user) { create_admin(division) }
+        scenario "old system menu shows" do
+          visit admin_loan_path(loan)
+          expect(page).to have_content("Transactions (old system)")
+        end
+      end
     end
   end
 
-  scenario 'loan can not be created with the same person as pri and sec agent' do
+  scenario "loan can not be created with the same person as pri and sec agent" do
     visit new_admin_loan_path
-    select user.name, from: 'loan_primary_agent_id'
-    select user.name, from: 'loan_secondary_agent_id'
-    click_on 'Create Loan'
-    expect(page).to have_content('The point person for this project cannot be the same as the second point person')
+    select user.name, from: "loan_primary_agent_id"
+    select user.name, from: "loan_secondary_agent_id"
+    click_on "Create Loan"
+    expect(page).to have_content(
+      "The point person for this project cannot be the same as the second point person"
+    )
   end
 
-  scenario 'loan with groups can be deleted' do
+  scenario "loan with groups can be deleted" do
     visit admin_loan_path(loan)
-    click_on 'Delete Loan'
-    expect(page).to have_content('Record was successfully deleted')
+    click_on "Delete Loan"
+    expect(page).to have_content("Record was successfully deleted")
   end
 end


### PR DESCRIPTION
A member no longer sees old system link:
<img width="1125" alt="Screen Shot 2021-05-28 at 12 32 52 PM" src="https://user-images.githubusercontent.com/4730344/120015806-c62ebb00-bfb1-11eb-97b2-9a656fa7081b.png">

... but a root admin does
<img width="1130" alt="Screen Shot 2021-05-28 at 12 33 18 PM" src="https://user-images.githubusercontent.com/4730344/120015794-c3cc6100-bfb1-11eb-8cb9-d2d054bdd4a5.png">

