### PR TITLE
11826: allow members to see transactions index

### DIFF
--- a/app/policies/accounting/transaction_policy.rb
+++ b/app/policies/accounting/transaction_policy.rb
@@ -1,6 +1,7 @@
 class Accounting::TransactionPolicy < ApplicationPolicy
   def index?
-    machine_user_or_appropriate_division_admin?
+    member_level_access = user && user != :machine && user.accessible_division_ids.include?(division.id)
+    member_level_access || machine_user_or_appropriate_division_admin?
   end
 
   def show?

--- a/spec/policies/accounting/transaction_policy_spec.rb
+++ b/spec/policies/accounting/transaction_policy_spec.rb
@@ -22,7 +22,7 @@ describe Accounting::TransactionPolicy do
 
   context "with non-admin" do
     context "user has access to this division" do
-      let(:user) { create_member(division) }
+      let(:user) { create(:user, :member, division: division) }
       forbid_all_but_index
       it_behaves_like "returns no reasons even if issues other than user role"
     end

--- a/spec/policies/accounting/transaction_policy_spec.rb
+++ b/spec/policies/accounting/transaction_policy_spec.rb
@@ -21,9 +21,17 @@ describe Accounting::TransactionPolicy do
   end
 
   context 'with non-admin' do
-    let(:user) { create(:user) }
-    forbid_all
-    it_behaves_like 'returns no reasons even if issues other than user role'
+    context 'user has access to this division' do
+      let(:user) { create_member(division) }
+      forbid_all_but_index
+      it_behaves_like 'returns no reasons even if issues other than user role'
+    end
+
+    context 'user does not have access to this division' do
+      let(:user) { create(:user) }
+      forbid_all
+      it_behaves_like 'returns no reasons even if issues other than user role'
+    end
   end
 
   context 'with admin of wrong division' do
@@ -34,7 +42,7 @@ describe Accounting::TransactionPolicy do
 
   context 'with admin of division but not parent_division' do
     let(:user) { create(:user, :admin, division: division) }
-    forbid_all
+    forbid_all_but_index
     it_behaves_like 'returns no reasons even if issues other than user role'
   end
 

--- a/spec/policies/accounting/transaction_policy_spec.rb
+++ b/spec/policies/accounting/transaction_policy_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Accounting::TransactionPolicy do
   let(:parent_division) { create(:division, :with_accounts, qb_read_only: false) }
@@ -11,91 +11,91 @@ describe Accounting::TransactionPolicy do
   let(:described_transaction) { Accounting::Transaction.new(project: loan) }
   subject(:policy) { described_class.new(user, described_transaction) }
 
-  shared_examples_for 'returns no reasons even if issues other than user role' do
+  shared_examples_for "returns no reasons even if issues other than user role" do
     it { expect(policy.read_only_reasons).to be_empty }
 
-    context 'with other issues present' do
+    context "with other issues present" do
       let(:loan_trait) { :completed }
       it { expect(policy.read_only_reasons).to be_empty }
     end
   end
 
-  context 'with non-admin' do
-    context 'user has access to this division' do
+  context "with non-admin" do
+    context "user has access to this division" do
       let(:user) { create_member(division) }
       forbid_all_but_index
-      it_behaves_like 'returns no reasons even if issues other than user role'
+      it_behaves_like "returns no reasons even if issues other than user role"
     end
 
-    context 'user does not have access to this division' do
+    context "user does not have access to this division" do
       let(:user) { create(:user) }
       forbid_all
-      it_behaves_like 'returns no reasons even if issues other than user role'
+      it_behaves_like "returns no reasons even if issues other than user role"
     end
   end
 
-  context 'with admin of wrong division' do
+  context "with admin of wrong division" do
     let(:user) { create(:user, :admin, division: create(:division)) }
     forbid_all
-    it_behaves_like 'returns no reasons even if issues other than user role'
+    it_behaves_like "returns no reasons even if issues other than user role"
   end
 
-  context 'with admin of division but not parent_division' do
+  context "with admin of division but not parent_division" do
     let(:user) { create(:user, :admin, division: division) }
     forbid_all_but_index
-    it_behaves_like 'returns no reasons even if issues other than user role'
+    it_behaves_like "returns no reasons even if issues other than user role"
   end
 
-  context 'with admin of division and no qb connection (so no qb_division)' do
+  context "with admin of division and no qb connection (so no qb_division)" do
     let(:user) { create(:user, :admin, division: division) }
     let(:division) { create(:division, :with_qb_dept, parent: Division.root) } # Root has no qb connection
     forbid_all_but_read
     it { expect(policy.read_only_reasons).to contain_exactly(:qb_not_connected) }
   end
 
-  shared_examples_for 'appropriate admin or machine user' do
-    context 'with all other things in order' do
+  shared_examples_for "appropriate admin or machine user" do
+    context "with all other things in order" do
       permit_actions [:index, :show, :create, :update, :sync]
       forbid_actions [:destroy]
     end
 
-    context 'with no qb_connection on parent or child division' do
+    context "with no qb_connection on parent or child division" do
       let(:parent_division) { create(:division) }
       forbid_all_but_read
       it { expect(policy.read_only_reasons).to contain_exactly(:qb_not_connected) }
     end
 
-    context 'with accounts not selected' do
+    context "with accounts not selected" do
       let(:parent_division) { create(:division, :with_qb_connection, qb_read_only: false) }
       forbid_all_but_read
       it { expect(policy.read_only_reasons).to contain_exactly(:accounts_not_selected) }
     end
 
-    context 'with division transactions read only' do
+    context "with division transactions read only" do
       let(:parent_division) { create(:division, :with_accounts, qb_read_only: true) }
       forbid_all_but_read
       it { expect(policy.read_only_reasons).to contain_exactly(:division_transactions_read_only) }
     end
 
-    context 'with department not set' do
+    context "with department not set" do
       let(:division) { create(:division, parent: parent_division) }
       forbid_all_but_read
       it { expect(policy.read_only_reasons).to contain_exactly(:department_not_set) }
     end
 
-    context 'with loan inactive' do
+    context "with loan inactive" do
       let(:loan_trait) { :completed }
       forbid_all_but_read
       it { expect(policy.read_only_reasons).to contain_exactly(:loan_not_active) }
     end
 
-    context 'with loan transactions read only' do
+    context "with loan transactions read only" do
       let(:loan_txn_mode) { Loan::TXN_MODE_READ_ONLY }
       forbid_all_but_read
       it { expect(policy.read_only_reasons).to contain_exactly(:loan_transactions_read_only) }
     end
 
-    context 'with multiple issues' do
+    context "with multiple issues" do
       let(:loan_trait) { :completed }
       let(:loan_txn_mode) { Loan::TXN_MODE_READ_ONLY }
 
@@ -107,13 +107,13 @@ describe Accounting::TransactionPolicy do
     end
   end
 
-  context 'with admin of parent_division' do
+  context "with admin of parent_division" do
     let(:user) { create(:user, :admin, division: parent_division) }
-    it_behaves_like 'appropriate admin or machine user'
+    it_behaves_like "appropriate admin or machine user"
   end
 
-  context 'with :machine user' do
+  context "with :machine user" do
     let(:user) { :machine }
-    it_behaves_like 'appropriate admin or machine user'
+    it_behaves_like "appropriate admin or machine user"
   end
 end


### PR DESCRIPTION
members (non admins) should be able to see the transactions tab for any loan they can see. 

