### PR TITLE
11825: remove active scope from fetch qb changes job, rely on txn pol…

### DIFF
--- a/app/jobs/fetch_quickbooks_changes_job.rb
+++ b/app/jobs/fetch_quickbooks_changes_job.rb
@@ -3,7 +3,7 @@ class FetchQuickbooksChangesJob < QuickbooksUpdateJob
 
   def loans
     @loans ||= divisions.map do |division|
-      division.loans.changed_since(updater.qb_connection.last_updated_at).active
+      division.loans.changed_since(updater.qb_connection.last_updated_at)
     end.flatten.compact
   end
 end


### PR DESCRIPTION
There is a non-active loan that Eden updated in QB. She needs to be able to see those changes in Madeline. 

The quickest way to support this is to remove the active scope on the fetch changes job. We want to do this in general, since Madeline should know what QB knows about any loans with transactions, regardless of whether they are active. That was there as a precaution before the big transactions policy refactor which does the job of making sure we don't run interest calculation on non-active loans. 

We need to add a spec for the job, and I'm glad to pair on that this week. I do want to get this up on prod today so Eden can fix this last thing.

UPDATE: realized the specific qb change should have come in thru a nightly update, so I am also looking into that. 

