### PR TITLE
11825 new qb data not coming in

### DIFF
--- a/app/jobs/fetch_quickbooks_changes_job.rb
+++ b/app/jobs/fetch_quickbooks_changes_job.rb
@@ -3,7 +3,7 @@ class FetchQuickbooksChangesJob < QuickbooksUpdateJob
 
   def loans
     @loans ||= divisions.map do |division|
-      division.loans.changed_since(updater.qb_connection.last_updated_at).active
+      division.loans.changed_since(updater.qb_connection.last_updated_at)
     end.flatten.compact
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,25 +1,20 @@
-set :output, 'log/cron.log'
+set :output, "log/cron.log"
 
 job_type :rbenv_rake, %Q{ eval "$(rbenv init -)"; cd :path && bundle exec rake :task --silent :output }
 
-env :PATH, ENV['PATH']
-env :GEM_HOME, ENV['GEM_HOME']
+env :PATH, ENV["PATH"]
+env :GEM_HOME, ENV["GEM_HOME"]
 
-every 1.day, at: '3am' do
-  runner 'RecalculateAllLoanHealthJob.perform_later'
+every 1.day, at: "3am" do
+  runner "RecalculateAllLoanHealthJob.perform_later"
 end
 
-every 1.day, at: '2am' do
-  case @environment
-  when 'production'
-    rake "madeline:enqueue_update_loans_task"
-  when 'staging'
-    rbenv_rake "madeline:enqueue_update_loans_task"
-  end
+every 1.day, at: "2am" do
+  rbenv_rake "madeline:enqueue_update_loans_task"
 end
 
 # built in script job type is not updated for rails 4 and higher
-job_type :script, 'cd :path && RAILS_ENV=:environment bundle exec bin/:task :output'
+job_type :script, "cd :path && RAILS_ENV=:environment bundle exec bin/:task :output"
 every :reboot do
-  script 'sidekiq'
+  script "sidekiq"
 end


### PR DESCRIPTION
There is a non-active loan that Eden updated in QB. She needs to be able to see those changes in Madeline. There are two ways these changes should be available, but there are problems with each. This pr has immediate fixes for these.

fetch changes from Quickbooks link: This link had an 'active' scope on it.  That was there as a precaution before the big transactions policy refactor which does the job of making sure we don't run interest calculation on non-active loans. We do want to pull QB changes on non-active loans, since Madeline should know what QB knows about any loans with transactions, regardless of whether they are active.  [we still need to do a spec on these jobs, I can work on that tmrw with some pairing]

nightly update all loans job: This job has not been running on production. This is most likely because we failed to undo a workaround in the schedule.rb file that was waiting for the production server upgrade which has happened -  https://github.com/sassafrastech/madeline/pull/885