### PR TITLE
11829: show interest txns before corresponding one

### DIFF
--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -192,12 +192,7 @@ module Admin
       @transactions.includes(:account, :project, :currency, :line_items).standard_order
       @enable_export_to_csv = true
       @transactions_grid = initialize_grid(
-        @transactions,
-        order: "accounting_transactions.txn_date",
-        custom_order: {
-          "accounting_transactions.txn_date" =>
-            "accounting_transactions.txn_date, length(accounting_transactions.loan_transaction_type_value)"
-        },
+        @transactions.standard_order,
         enable_export_to_csv: @enable_export_to_csv,
         per_page: 100,
         name: "transactions"

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -178,7 +178,7 @@ module Admin
       return if @attached_links.empty?
 
       open_link_text = view_context.link_to(I18n.t("loan.open_links", count: @attached_links.length),
-        "#", data: {action: "open-links", links: @attached_links})
+                                            "#", data: {action: "open-links", links: @attached_links})
       notice_text = "".html_safe
       notice_text << I18n.t("loan.num_of_links", count: @attached_links.length) << " " << open_link_text
       notice_text << " " << I18n.t("loan.popup_blocker") if @attached_links.length > 1
@@ -191,10 +191,18 @@ module Admin
       @transactions = ::Accounting::Transaction.where(project: @loan).extracted
       @transactions.includes(:account, :project, :currency, :line_items).standard_order
       @enable_export_to_csv = true
-      @transactions_grid = initialize_grid(@transactions, order: 'accounting_transactions.txn_date',
-                                                          enable_export_to_csv: @enable_export_to_csv,
-                                                          per_page: 100, name: 'transactions')
-      export_grid_if_requested('transactions': 'admin/accounting/transactions/transactions_grid_definition')
+      @transactions_grid = initialize_grid(
+        @transactions,
+        order: "accounting_transactions.txn_date",
+        custom_order: {
+          "accounting_transactions.txn_date" =>
+            "accounting_transactions.txn_date, length(accounting_transactions.loan_transaction_type_value)"
+        },
+        enable_export_to_csv: @enable_export_to_csv,
+        per_page: 100,
+        name: "transactions"
+      )
+      export_grid_if_requested('transactions': "admin/accounting/transactions/transactions_grid_definition")
       show_reasons_if_read_only
     end
 
@@ -205,11 +213,11 @@ module Admin
       args[:current_division] = @loan.division.name
       args[:qb_division] = @loan.qb_division&.name
       args[:qb_division_settings_link] =
-        view_context.link_to(t('common.settings'), admin_division_path(@loan.division))
+        view_context.link_to(t("common.settings"), admin_division_path(@loan.division))
       args[:accounting_settings_link] =
-        view_context.link_to(t('common.settings'), admin_accounting_settings_path)
+        view_context.link_to(t("common.settings"), admin_accounting_settings_path)
       reasons = reasons.map { |r| t("quickbooks.read_only_reasons.#{r}_html", args) }.join("; ")
-      flash.now[:alert] = t('quickbooks.read_only_html', reasons: reasons)
+      flash.now[:alert] = t("quickbooks.read_only_html", reasons: reasons)
     end
   end
 end

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -126,7 +126,6 @@ feature "transaction flow", :accounting do
 
       it "places interest txns before accompanying disbursement or repayment" do
         visit "/admin/loans/#{loan.id}/transactions"
-        save_and_open_page
         expect_ledger_row_col_to_contain(row: 1, col: 1, content: "January 1, 2020")
         expect_ledger_row_col_to_contain(row: 1, col: 2, content: "Interest")
         expect_ledger_row_col_to_contain(row: 2, col: 1, content: "January 1, 2020")

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -126,16 +126,17 @@ feature "transaction flow", :accounting do
 
       it "places interest txns before accompanying disbursement or repayment" do
         visit "/admin/loans/#{loan.id}/transactions"
-        expect_ledger_row_column_to_contain(1, 1, "January 1, 2020")
-        expect_ledger_row_column_to_contain(1, 2, "Interest")
-        expect_ledger_row_column_to_contain(2, 1, "January 1, 2020")
-        expect_ledger_row_column_to_contain(2, 2, "Disbursement")
-        expect_ledger_row_column_to_contain(3, 1, "January 31, 2020")
-        expect_ledger_row_column_to_contain(3, 2, "Interest")
-        expect_ledger_row_column_to_contain(4, 1, "February 15, 2020")
-        expect_ledger_row_column_to_contain(4, 2, "Interest")
-        expect_ledger_row_column_to_contain(5, 1, "February 15, 2020")
-        expect_ledger_row_column_to_contain(5, 2, "Repayment")
+        save_and_open_page
+        expect_ledger_row_col_to_contain(row: 1, col: 1, content: "January 1, 2020")
+        expect_ledger_row_col_to_contain(row: 1, col: 2, content: "Interest")
+        expect_ledger_row_col_to_contain(row: 2, col: 1, content: "January 1, 2020")
+        expect_ledger_row_col_to_contain(row: 2, col: 2, content: "Disbursement")
+        expect_ledger_row_col_to_contain(row: 3, col: 1, content: "January 31, 2020")
+        expect_ledger_row_col_to_contain(row: 3, col: 2, content: "Interest")
+        expect_ledger_row_col_to_contain(row: 4, col: 1, content: "February 15, 2020")
+        expect_ledger_row_col_to_contain(row: 4, col: 2, content: "Interest")
+        expect_ledger_row_col_to_contain(row: 5, col: 1, content: "February 15, 2020")
+        expect_ledger_row_col_to_contain(row: 5, col: 2, content: "Repayment")
       end
     end
 
@@ -263,8 +264,8 @@ feature "transaction flow", :accounting do
     fill_in "Memo", with: "Chunky monkey"
   end
 
-  def expect_ledger_row_column_to_contain(row, column, content)
-    within(:xpath, "//tbody/tr[#{row}]/td[#{column}]") do
+  def expect_ledger_row_col_to_contain(row: nil, col: nil, content: nil)
+    within(:xpath, "//tbody/tr[#{row}]/td[#{col}]") do
       expect(page).to have_content(content)
     end
   end

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -126,7 +126,6 @@ feature "transaction flow", :accounting do
 
       it "places interest txns before accompanying disbursement or repayment" do
         visit "/admin/loans/#{loan.id}/transactions"
-        save_and_open_page
         expect_ledger_row_column_to_contain(1, 1, "January 1, 2020")
         expect_ledger_row_column_to_contain(1, 2, "Interest")
         expect_ledger_row_column_to_contain(2, 1, "January 1, 2020")


### PR DESCRIPTION



Relies on automatic test. 

To QA on staging: for a repayment & interest txn on same date, interest should appear first. likewise for a disbursement & interest txn on same date, interest should appear first. 