### PR TITLE
11831 fix error updating non madeline txn

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,7 +43,7 @@ Metrics:
   Enabled: false
 
 Metrics/BlockLength:
-  Enabled: true
+  Enabled: false
 
 Style:
   Enabled: false

--- a/app/controllers/admin/accounting/transactions_controller.rb
+++ b/app/controllers/admin/accounting/transactions_controller.rb
@@ -24,7 +24,7 @@ class Admin::Accounting::TransactionsController < Admin::AdminController
   end
 
   def create
-    @transaction = ::Accounting::Transaction.new(transaction_params.merge(project_id: params[:project_id]))
+    @transaction = sample_transaction(transaction_params.merge(project_id: params[:project_id]))
     authorize(@transaction, :create?)
     @loan = @transaction.project
     @transaction.user_created = true
@@ -169,7 +169,8 @@ class Admin::Accounting::TransactionsController < Admin::AdminController
     view_context.link_to(t('menu.accounting_settings'), admin_accounting_settings_path)
   end
 
-  def sample_transaction
-    ::Accounting::Transaction.new(project: @loan, txn_date: Time.zone.today)
+  def sample_transaction(attrs = {})
+    most_likely_editable_attrs = {project: @loan, txn_date: Time.zone.today, managed: true, loan_transaction_type_value: :disbursement}
+    ::Accounting::Transaction.new(most_likely_editable_attrs.merge(attrs))
   end
 end

--- a/app/controllers/admin/accounting/transactions_controller.rb
+++ b/app/controllers/admin/accounting/transactions_controller.rb
@@ -170,7 +170,7 @@ class Admin::Accounting::TransactionsController < Admin::AdminController
   end
 
   def sample_transaction(attrs = {})
-    most_likely_editable_attrs = {project: @loan, txn_date: Time.zone.today, managed: true, loan_transaction_type_value: :disbursement}
+    most_likely_editable_attrs = {project: @loan, txn_date: Time.zone.today, managed: true}
     ::Accounting::Transaction.new(most_likely_editable_attrs.merge(attrs))
   end
 end

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -54,7 +54,7 @@ module Admin
         prep_logs(@loan)
       when "transactions"
         # requires additional level of validation beyond approrpiate loan access
-        @sample_transaction = ::Accounting::Transaction.new(project: @loan, managed: true, loan_transaction_type_value: :disbursement)
+        @sample_transaction = ::Accounting::Transaction.new(project: @loan, managed: true)
         authorize @sample_transaction, :index?
         prep_transactions
       when "calendar"

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -54,7 +54,7 @@ module Admin
         prep_logs(@loan)
       when "transactions"
         # requires additional level of validation beyond approrpiate loan access
-        @sample_transaction = ::Accounting::Transaction.new(project: @loan)
+        @sample_transaction = ::Accounting::Transaction.new(project: @loan, managed: true, loan_transaction_type_value: :disbursement)
         authorize @sample_transaction, :index?
         prep_transactions
       when "calendar"

--- a/app/models/accounting/interest_calculator.rb
+++ b/app/models/accounting/interest_calculator.rb
@@ -59,7 +59,8 @@ module Accounting
     end
 
     def recalculate
-      return unless TransactionPolicy.new(:machine, Transaction.new(project: @loan)).create?
+      # check if a generic non-interest, managed txn for this loan can be written
+      return unless TransactionPolicy.new(:machine, Transaction.new(project: @loan, managed: true, loan_transaction_type_value: :disbursement)).create?
       return if transactions.empty?
 
       prev_tx = nil

--- a/app/models/accounting/interest_calculator.rb
+++ b/app/models/accounting/interest_calculator.rb
@@ -60,7 +60,7 @@ module Accounting
 
     def recalculate
       # check if a generic non-interest, managed txn for this loan can be written
-      return unless TransactionPolicy.new(:machine, Transaction.new(project: @loan, managed: true, loan_transaction_type_value: :disbursement)).create?
+      return unless TransactionPolicy.new(:machine, Transaction.new(project: @loan, managed: true)).create?
       return if transactions.empty?
 
       prev_tx = nil

--- a/app/models/accounting/qb/transaction_class_finder.rb
+++ b/app/models/accounting/qb/transaction_class_finder.rb
@@ -2,8 +2,6 @@ module Accounting
   module QB
     class FindError < StandardError; end
 
-    # This class is responsible for batching up Quickbooks API calls into separate types.
-    # The API does support batch requests for queries, but quickbooks-ruby does not.
     class TransactionClassFinder
       attr_reader :qb_connection
       attr_accessor :division

--- a/app/policies/accounting/transaction_policy.rb
+++ b/app/policies/accounting/transaction_policy.rb
@@ -9,7 +9,10 @@ class Accounting::TransactionPolicy < ApplicationPolicy
   end
 
   def create?
-    machine_user_or_appropriate_division_admin? && record.managed? && !record.interest? && read_only_reasons.none?
+    machine_user_or_appropriate_division_admin? &&
+      record.managed? &&
+      !record.interest? &&
+      read_only_reasons.none?
   end
 
   def update?

--- a/app/policies/accounting/transaction_policy.rb
+++ b/app/policies/accounting/transaction_policy.rb
@@ -9,7 +9,7 @@ class Accounting::TransactionPolicy < ApplicationPolicy
   end
 
   def create?
-    machine_user_or_appropriate_division_admin? && read_only_reasons.none?
+    machine_user_or_appropriate_division_admin? && record.managed? && !record.interest? && read_only_reasons.none?
   end
 
   def update?

--- a/app/views/admin/accounting/transactions/_modal_content.slim
+++ b/app/views/admin/accounting/transactions/_modal_content.slim
@@ -8,7 +8,7 @@ div.modal-header
       = @transaction.description
 
 div.modal-body
-  - unless @transaction.new_record? || @transaction.type?("interest")
+  - if !@transaction.new_record? && policy(@transaction).update?
     .show-actions
       a.edit-action.view-element
         i.fa.fa-pencil.fa-large>

--- a/app/views/admin/accounting/transactions/_modal_content.slim
+++ b/app/views/admin/accounting/transactions/_modal_content.slim
@@ -8,7 +8,7 @@ div.modal-header
       = @transaction.description
 
 div.modal-body
-  - if !@transaction.new_record? && policy(@transaction).update?
+  - if @transaction.persisted? && policy(@transaction).update?
     .show-actions
       a.edit-action.view-element
         i.fa.fa-pencil.fa-large>

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -158,6 +158,7 @@ feature "transaction flow", :accounting do
         expect(page).not_to have_content("Vendor")
         expect(page).not_to have_content("Check Number")
         choose "Disbursement"
+        save_and_open_page
         expect(page).to have_content("Disbursement Type")
         expect(page).to have_content("Vendor")
         expect(page).not_to have_content("Check Number")
@@ -249,6 +250,32 @@ feature "transaction flow", :accounting do
       visit admin_loan_tab_path(loan, tab: "transactions")
       click_on txn.txn_date.strftime("%B %-d, %Y")
       expect(page).to have_content("icecream")
+    end
+
+    describe "an admin can edit a managed txn" do
+      let!(:txn) do
+        create(:accounting_transaction,
+               project_id: loan.id, description: "I love icecream", division: division, managed: true)
+      end
+
+      scenario "edit managed transaction as admin" do
+        visit admin_loan_tab_path(loan, tab: "transactions")
+        click_on txn.txn_date.strftime("%B %-d, %Y")
+        expect(page).to have_content("Edit")
+      end
+    end
+
+    describe "an admin cannot edit a non-managed txn" do
+      let!(:txn) do
+        create(:accounting_transaction,
+               project_id: loan.id, description: "I love icecream", division: division, managed: false)
+      end
+
+      scenario "edit managed transaction as admin" do
+        visit admin_loan_tab_path(loan, tab: "transactions")
+        click_on txn.txn_date.strftime("%B %-d, %Y")
+        expect(page).not_to have_content("Edit")
+      end
     end
   end
 

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -158,7 +158,6 @@ feature "transaction flow", :accounting do
         expect(page).not_to have_content("Vendor")
         expect(page).not_to have_content("Check Number")
         choose "Disbursement"
-        save_and_open_page
         expect(page).to have_content("Disbursement Type")
         expect(page).to have_content("Vendor")
         expect(page).not_to have_content("Check Number")
@@ -252,13 +251,13 @@ feature "transaction flow", :accounting do
       expect(page).to have_content("icecream")
     end
 
-    describe "an admin can edit a managed txn" do
+    describe "an admin can edit a managed non-interest txn" do
       let!(:txn) do
         create(:accounting_transaction,
                project_id: loan.id, description: "I love icecream", division: division, managed: true)
       end
 
-      scenario "edit managed transaction as admin" do
+      scenario do
         visit admin_loan_tab_path(loan, tab: "transactions")
         click_on txn.txn_date.strftime("%B %-d, %Y")
         expect(page).to have_content("Edit")
@@ -271,7 +270,20 @@ feature "transaction flow", :accounting do
                project_id: loan.id, description: "I love icecream", division: division, managed: false, loan_transaction_type_value: :disbursement)
       end
 
-      scenario "edit managed transaction as admin" do
+      scenario do
+        visit admin_loan_tab_path(loan, tab: "transactions")
+        click_on txn.txn_date.strftime("%B %-d, %Y")
+        expect(page).not_to have_content("Edit")
+      end
+    end
+
+    describe "an admin cannot edit a managed interest txn" do
+      let!(:txn) do
+        create(:accounting_transaction,
+               project_id: loan.id, description: "I love icecream", division: division, managed: true, loan_transaction_type_value: :interest)
+      end
+
+      scenario do
         visit admin_loan_tab_path(loan, tab: "transactions")
         click_on txn.txn_date.strftime("%B %-d, %Y")
         expect(page).not_to have_content("Edit")

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -268,7 +268,7 @@ feature "transaction flow", :accounting do
     describe "an admin cannot edit a non-managed txn" do
       let!(:txn) do
         create(:accounting_transaction,
-               project_id: loan.id, description: "I love icecream", division: division, managed: false)
+               project_id: loan.id, description: "I love icecream", division: division, managed: false, loan_transaction_type_value: :disbursement)
       end
 
       scenario "edit managed transaction as admin" do

--- a/spec/features/admin/accounting/transaction_flow_spec.rb
+++ b/spec/features/admin/accounting/transaction_flow_spec.rb
@@ -254,7 +254,11 @@ feature "transaction flow", :accounting do
     describe "an admin can edit a managed non-interest txn" do
       let!(:txn) do
         create(:accounting_transaction,
-               project_id: loan.id, description: "I love icecream", division: division, managed: true)
+               project_id: loan.id,
+               description: "I love icecream",
+               division: division,
+               managed: true,
+               loan_transaction_type_value: :disbursement)
       end
 
       scenario do
@@ -267,7 +271,11 @@ feature "transaction flow", :accounting do
     describe "an admin cannot edit a non-managed txn" do
       let!(:txn) do
         create(:accounting_transaction,
-               project_id: loan.id, description: "I love icecream", division: division, managed: false, loan_transaction_type_value: :disbursement)
+               project_id: loan.id,
+               description: "I love icecream",
+               division: division,
+               managed: false,
+               loan_transaction_type_value: :disbursement)
       end
 
       scenario do
@@ -280,7 +288,11 @@ feature "transaction flow", :accounting do
     describe "an admin cannot edit a managed interest txn" do
       let!(:txn) do
         create(:accounting_transaction,
-               project_id: loan.id, description: "I love icecream", division: division, managed: true, loan_transaction_type_value: :interest)
+               project_id: loan.id,
+               description: "I love icecream",
+               division: division,
+               managed: true,
+               loan_transaction_type_value: :interest)
       end
 
       scenario do

--- a/spec/models/accounting/qb/full_fetcher_spec.rb
+++ b/spec/models/accounting/qb/full_fetcher_spec.rb
@@ -102,9 +102,9 @@ describe Accounting::QB::FullFetcher, type: :model do
       new_account_ids = division.accounts.map(&:id)
 
       # Accounts should be restored with the same QB ids but they should have different DB ids
-      expect(division.accounts.count).to eq 3
+      expect(division.reload.accounts.count).to eq 3
       expect(stored_account_ids).not_to match_array new_account_ids
-      expect(division.qb_department.name).to eq qb_department.name
+      expect(division.reload.qb_department.name).to eq qb_department.name
     end
 
     context "qb fetch errors" do

--- a/spec/models/accounting/qb/purchase_extractor_spec.rb
+++ b/spec/models/accounting/qb/purchase_extractor_spec.rb
@@ -17,7 +17,10 @@ describe Accounting::QB::PurchaseExtractor, type: :model do
       credit_accounts: [txn_acct],
       type: "Purchase",
       total: 12345.67,
-      doc_number: "from qb")
+      doc_number: "from qb",
+      sync_token: "abc",
+      payment_type: "Check"
+    )
   end
   let(:txn) { Accounting::Transaction.create_or_update_from_qb_object!(qb_object_type: "Purchase", qb_object: quickbooks_data) }
 
@@ -31,6 +34,8 @@ describe Accounting::QB::PurchaseExtractor, type: :model do
       expect(txn.line_items[1].credit?).to be true
       expect(txn.account).to eq txn_acct
       expect(txn.amount).to equal_money(12345.67)
+      expect(txn.sync_token).to eq "abc"
+      expect(txn.qb_object_subtype).to eq "Check"
       expect { txn.save! }.not_to raise_error
     end
   end

--- a/spec/models/accounting/qb/purchase_extractor_spec.rb
+++ b/spec/models/accounting/qb/purchase_extractor_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe Accounting::QB::PurchaseExtractor, type: :model do
   let(:qb_id) { 1982547353 }
@@ -6,28 +6,32 @@ describe Accounting::QB::PurchaseExtractor, type: :model do
   let(:prin_acct) { division.principal_account }
   let(:int_inc_acct) { division.interest_income_account }
   let(:int_rcv_acct) { division.interest_receivable_account }
-  let(:txn_acct) { create(:account, name: 'Some Bank Account') }
-  let(:random_acct) { create(:account, name: 'Another Bank Account') }
+  let(:txn_acct) { create(:account, name: "Some Bank Account") }
+  let(:random_acct) { create(:account, name: "Another Bank Account") }
   let(:loan) { create(:loan, division: division) }
 
   let(:quickbooks_data) do
     create(:transaction_json,
-      loan: loan,
-      debit_accounts: [prin_acct],
-      credit_accounts: [txn_acct],
-      type: "Purchase",
-      total: 12345.67,
-      doc_number: "from qb",
-      sync_token: "abc",
-      payment_type: "Check"
+           loan: loan,
+           debit_accounts: [prin_acct],
+           credit_accounts: [txn_acct],
+           type: "Purchase",
+           total: 12345.67,
+           doc_number: "from qb",
+           sync_token: "abc",
+           payment_type: "Check")
+  end
+  let(:txn) do
+    Accounting::Transaction.create_or_update_from_qb_object!(
+      qb_object_type: "Purchase",
+      qb_object: quickbooks_data
     )
   end
-  let(:txn) { Accounting::Transaction.create_or_update_from_qb_object!(qb_object_type: "Purchase", qb_object: quickbooks_data) }
 
-  context 'extract!' do
-    it 'updates correctly in Madeline' do
+  context "extract!" do
+    it "updates correctly in Madeline" do
       Accounting::QB::PurchaseExtractor.new(txn).extract!
-      expect(txn.loan_transaction_type_value).to eq 'disbursement'
+      expect(txn.loan_transaction_type_value).to eq "disbursement"
       expect(txn.managed).to be false
       expect(txn.line_items.size).to eq 2
       expect(txn.line_items[1].account).to eq txn.account

--- a/spec/models/accounting/transaction_spec.rb
+++ b/spec/models/accounting/transaction_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Accounting::Transaction, type: :model do
   let(:division) { create(:division, :with_accounts) }
@@ -11,60 +11,55 @@ RSpec.describe Accounting::Transaction, type: :model do
   # The data are taken from the docs/example_calculation.xlsx file, row 7.
   let(:quickbooks_data) { create(:transaction_json, loan: loan) }
 
-  describe '.standard_order' do
+  describe ".standard_order" do
     let!(:txn_1) do
       create(:accounting_transaction,
-        txn_date: Date.today,
-        loan_transaction_type_value: 'repayment',
-        created_at: Time.now - 1.minutes
-      )
+             txn_date: Date.today,
+             loan_transaction_type_value: "repayment",
+             created_at: Time.now - 1.minute)
     end
     let!(:txn_2) do
       create(:accounting_transaction,
-        txn_date: Date.today,
-        loan_transaction_type_value: 'disbursement',
-        created_at: Time.now - 2.minutes
-      )
+             txn_date: Date.today,
+             loan_transaction_type_value: "disbursement",
+             created_at: Time.now - 2.minutes)
     end
     let!(:txn_3) do
       create(:accounting_transaction,
-        txn_date: Date.today - 3,
-        loan_transaction_type_value: 'disbursement',
-        created_at: Time.now - 3.minutes
-      )
+             txn_date: Date.today - 3,
+             loan_transaction_type_value: "disbursement",
+             created_at: Time.now - 3.minutes)
     end
     let!(:txn_4) do
       create(:accounting_transaction,
-        txn_date: Date.today - 3,
-        loan_transaction_type_value: 'interest',
-        created_at: Time.now - 10.minutes
-      )
+             txn_date: Date.today - 3,
+             loan_transaction_type_value: "interest",
+             created_at: Time.now - 10.minutes)
     end
     let!(:txn_5) do
       create(:accounting_transaction,
-        txn_date: Date.today - 3,
-        loan_transaction_type_value: 'interest',
-        created_at: Time.now - 5.minutes
-      )
+             txn_date: Date.today - 3,
+             loan_transaction_type_value: "interest",
+             created_at: Time.now - 5.minutes)
     end
 
     before do
       OptionSetCreator.new.create_loan_transaction_type
     end
 
-    it 'returns in the right order' do
+    it "returns in the right order" do
       expect(Accounting::Transaction.standard_order).to eq([txn_4, txn_5, txn_3, txn_2, txn_1])
     end
   end
 
-  describe '.create_or_update_from_qb_object!' do
-    it 'should set appropriate fields on create' do
-      qb_obj = double(id: 123, as_json: {'x' => 'y'})
-      txn = described_class.create_or_update_from_qb_object!(qb_object_type: 'JournalEntry', qb_object: qb_obj)
+  describe ".create_or_update_from_qb_object!" do
+    it "should set appropriate fields on create" do
+      qb_obj = double(id: 123, as_json: {"x" => "y"})
+      txn = described_class.create_or_update_from_qb_object!(qb_object_type: "JournalEntry", qb_object: qb_obj)
 
-      expect(txn.qb_object_type).to eq('JournalEntry')
-      expect(txn.qb_id).to eq('123')
-      expect(txn.quickbooks_data).to eq({'x' => 'y'})
+      expect(txn.qb_object_type).to eq("JournalEntry")
+      expect(txn.qb_id).to eq("123")
+      expect(txn.quickbooks_data).to eq({"x" => "y"})
       expect(txn.needs_qb_push).to be false
     end
 
@@ -74,46 +69,46 @@ RSpec.describe Accounting::Transaction, type: :model do
 
         it "associates QB #{type} txn with loan if there is a match" do
           qb_obj = double(id: 124, as_json: quickbooks_data)
-          txn = described_class.create_or_update_from_qb_object!(qb_object_type: 'Bill', qb_object: qb_obj)
+          txn = described_class.create_or_update_from_qb_object!(qb_object_type: "Bill", qb_object: qb_obj)
           expect(txn.project_id).to eq(loan.id)
         end
       end
     end
 
-    it 'associates old QB txn with loan if there is a match' do
+    it "associates old QB txn with loan if there is a match" do
       qb_obj = double(id: 124, as_json: quickbooks_data)
-      txn = described_class.create_or_update_from_qb_object!(qb_object_type: 'JournalEntry', qb_object: qb_obj)
+      txn = described_class.create_or_update_from_qb_object!(qb_object_type: "JournalEntry", qb_object: qb_obj)
 
       expect(txn.project_id).to eq(loan.id)
     end
   end
 
   # TODO: this block of specs, and accompanying #set_qb_object_type logic needs review
-  describe 'sets qb txn type and requires amount on madeline-created disbursements' do
+  describe "sets qb txn type and requires amount on madeline-created disbursements" do
     let(:transaction_params) do
       {
         amount: nil,
-        txn_date: '2017-10-31',
-        private_note: 'a memo',
-        description: 'desc',
+        txn_date: "2017-10-31",
+        private_note: "a memo",
+        description: "desc",
         project_id: loan.id,
         loan_transaction_type_value: transaction_type
       }
     end
 
-    context 'when disbursement transaction' do
-      let(:transaction_type) { 'disbursement' }
+    context "when disbursement transaction" do
+      let(:transaction_type) { "disbursement" }
 
-      context 'without qb_id' do
-        it 'requires an amount to save' do
+      context "without qb_id" do
+        it "requires an amount to save" do
           expect do
             create(:accounting_transaction, transaction_params.merge(qb_id: nil))
           end.to raise_error(ActiveRecord::RecordInvalid)
         end
       end
 
-      context 'with qb_id' do
-        it 'requires an amount to save' do
+      context "with qb_id" do
+        it "requires an amount to save" do
           expect do
             create(:accounting_transaction, transaction_params.merge(qb_id: 123))
           end.to raise_error(ActiveRecord::RecordInvalid)
@@ -138,9 +133,9 @@ RSpec.describe Accounting::Transaction, type: :model do
         let(:transaction_params) do
           {
             amount: 10,
-            txn_date: '2017-10-31',
-            private_note: 'a memo',
-            description: 'desc',
+            txn_date: "2017-10-31",
+            private_note: "a memo",
+            description: "desc",
             project_id: loan.id,
             loan_transaction_type_value: transaction_type,
             qb_object_subtype: "Check",
@@ -151,7 +146,7 @@ RSpec.describe Accounting::Transaction, type: :model do
 
         context "no check number" do
           let(:check_number) { nil }
-          it 'requires a check number to save' do
+          it "requires a check number to save" do
             expect do
               create(:accounting_transaction, transaction_params.merge({user_created: true}))
             end.to raise_error(ActiveRecord::RecordInvalid)
@@ -160,7 +155,7 @@ RSpec.describe Accounting::Transaction, type: :model do
 
         context "no vendor" do
           let(:vendor_id) { nil }
-          it 'requires a vendor to save when created by user' do
+          it "requires a vendor to save when created by user" do
             expect do
               create(:accounting_transaction, transaction_params.merge({user_created: true}))
             end.to raise_error(ActiveRecord::RecordInvalid)
@@ -169,11 +164,11 @@ RSpec.describe Accounting::Transaction, type: :model do
       end
     end
 
-    context 'when interest transaction' do
-      let(:transaction_type) { 'interest' }
+    context "when interest transaction" do
+      let(:transaction_type) { "interest" }
 
-      context 'without qb_id' do
-        it 'can save without amount' do
+      context "without qb_id" do
+        it "can save without amount" do
           expect do
             create(:accounting_transaction, transaction_params.merge(qb_id: nil))
           end.not_to raise_error
@@ -182,28 +177,28 @@ RSpec.describe Accounting::Transaction, type: :model do
     end
   end
 
-  context 'with line items' do
+  context "with line items" do
     let(:transaction) { create(:accounting_transaction, project: loan) }
     let(:txn) { transaction }
     let(:int_inc_acct) { transaction.division.interest_income_account }
     let(:int_rcv_acct) { transaction.division.interest_receivable_account }
     let(:prin_acct) { transaction.division.principal_account }
     let!(:line_items) do
-      create_line_item(txn, 'Debit', 1.02, account: prin_acct)
-      create_line_item(txn, 'Debit', 2.07, account: int_rcv_acct)
-      create_line_item(txn, 'Debit', 1.50, account: int_inc_acct)
-      create_line_item(txn, 'Credit', 1.15, account: prin_acct)
-      create_line_item(txn, 'Credit', 3.00, account: int_rcv_acct)
-      create_line_item(txn, 'Credit', 1.25, account: int_inc_acct)
+      create_line_item(txn, "Debit", 1.02, account: prin_acct)
+      create_line_item(txn, "Debit", 2.07, account: int_rcv_acct)
+      create_line_item(txn, "Debit", 1.50, account: int_inc_acct)
+      create_line_item(txn, "Credit", 1.15, account: prin_acct)
+      create_line_item(txn, "Credit", 3.00, account: int_rcv_acct)
+      create_line_item(txn, "Credit", 1.25, account: int_inc_acct)
 
       # These are decoy line items associated with random accounts that we don't care about.
       # They should not be included in the change_in_* calculations.
-      create_line_item(txn, 'Debit', 2.50)
-      create_line_item(txn, 'Credit', 1.69)
+      create_line_item(txn, "Debit", 2.50)
+      create_line_item(txn, "Credit", 1.69)
     end
 
-    describe '#change_in_principal and #change_in_interest' do
-      it 'calculates correctly' do
+    describe "#change_in_principal and #change_in_interest" do
+      it "calculates correctly" do
         transaction.calculate_deltas
         transaction.save
         expect(transaction.reload.change_in_principal).to equal_money(-0.13)
@@ -211,14 +206,14 @@ RSpec.describe Accounting::Transaction, type: :model do
       end
     end
 
-    describe '#calculate_balances' do
-      it 'works without previous transaction' do
+    describe "#calculate_balances" do
+      it "works without previous transaction" do
         transaction.calculate_balances
         expect(transaction.principal_balance).to equal_money(-0.13)
         expect(transaction.interest_balance).to equal_money(-0.93)
       end
 
-      it 'works with previous transaction' do
+      it "works with previous transaction" do
         prev_tx = create(:accounting_transaction, principal_balance: 6.22, interest_balance: 4.50)
 
         transaction.calculate_balances(prev_tx: prev_tx)

--- a/spec/models/accounting/transaction_spec.rb
+++ b/spec/models/accounting/transaction_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe Accounting::Transaction, type: :model do
     end
   end
 
-  describe 'qb_id' do
+  # TODO: this block of specs, and accompanying #set_qb_object_type logic needs review
+  describe 'sets qb txn type and requires amount on madeline-created disbursements' do
     let(:transaction_params) do
       {
         amount: nil,

--- a/spec/models/accounting/transaction_spec.rb
+++ b/spec/models/accounting/transaction_spec.rb
@@ -14,33 +14,33 @@ RSpec.describe Accounting::Transaction, type: :model do
   describe ".standard_order" do
     let!(:txn_1) do
       create(:accounting_transaction,
-             txn_date: Date.today,
+             txn_date: Time.zone.today,
              loan_transaction_type_value: "repayment",
-             created_at: Time.now - 1.minute)
+             created_at: Time.zone.now - 1.minute)
     end
     let!(:txn_2) do
       create(:accounting_transaction,
-             txn_date: Date.today,
+             txn_date: Time.zone.today,
              loan_transaction_type_value: "disbursement",
-             created_at: Time.now - 2.minutes)
+             created_at: Time.zone.now - 2.minutes)
     end
     let!(:txn_3) do
       create(:accounting_transaction,
-             txn_date: Date.today - 3,
+             txn_date: Time.zone.today - 3,
              loan_transaction_type_value: "disbursement",
-             created_at: Time.now - 3.minutes)
+             created_at: Time.zone.now - 3.minutes)
     end
     let!(:txn_4) do
       create(:accounting_transaction,
-             txn_date: Date.today - 3,
+             txn_date: Time.zone.today - 3,
              loan_transaction_type_value: "interest",
-             created_at: Time.now - 10.minutes)
+             created_at: Time.zone.now - 10.minutes)
     end
     let!(:txn_5) do
       create(:accounting_transaction,
-             txn_date: Date.today - 3,
+             txn_date: Time.zone.today - 3,
              loan_transaction_type_value: "interest",
-             created_at: Time.now - 5.minutes)
+             created_at: Time.zone.now - 5.minutes)
     end
 
     before do
@@ -55,7 +55,9 @@ RSpec.describe Accounting::Transaction, type: :model do
   describe ".create_or_update_from_qb_object!" do
     it "should set appropriate fields on create" do
       qb_obj = double(id: 123, as_json: {"x" => "y"})
-      txn = described_class.create_or_update_from_qb_object!(qb_object_type: "JournalEntry", qb_object: qb_obj)
+      txn = described_class.create_or_update_from_qb_object!(
+        qb_object_type: "JournalEntry", qb_object: qb_obj
+      )
 
       expect(txn.qb_object_type).to eq("JournalEntry")
       expect(txn.qb_id).to eq("123")
@@ -77,7 +79,9 @@ RSpec.describe Accounting::Transaction, type: :model do
 
     it "associates old QB txn with loan if there is a match" do
       qb_obj = double(id: 124, as_json: quickbooks_data)
-      txn = described_class.create_or_update_from_qb_object!(qb_object_type: "JournalEntry", qb_object: qb_obj)
+      txn = described_class.create_or_update_from_qb_object!(
+        qb_object_type: "JournalEntry", qb_object: qb_obj
+      )
 
       expect(txn.project_id).to eq(loan.id)
     end
@@ -122,7 +126,9 @@ RSpec.describe Accounting::Transaction, type: :model do
       end
 
       it "has qb object type je if was je and has qb_id" do
-        txn = Accounting::Transaction.new(transaction_params.merge(qb_id: "1", qb_object_type: "JournalEntry"))
+        txn = Accounting::Transaction.new(
+          transaction_params.merge(qb_id: "1", qb_object_type: "JournalEntry")
+        )
         txn.save
         expect(txn.reload.qb_object_type).to eq "JournalEntry"
       end

--- a/spec/policies/accounting/transaction_policy_spec.rb
+++ b/spec/policies/accounting/transaction_policy_spec.rb
@@ -102,7 +102,7 @@ describe Accounting::TransactionPolicy do
       end
 
       context "ms-managed interest transaction" do
-        let(:described_transaction) { Accounting::Transaction.new(project: loan, managed: false, loan_transaction_type_value: :interest) }
+        let(:described_transaction) { Accounting::Transaction.new(project: loan, managed: true, loan_transaction_type_value: :interest) }
         forbid_all_but_read
       end
     end

--- a/spec/policies/accounting/transaction_policy_spec.rb
+++ b/spec/policies/accounting/transaction_policy_spec.rb
@@ -8,7 +8,7 @@ describe Accounting::TransactionPolicy do
   let(:loan_trait) { :active }
   let(:loan_txn_mode) { Loan::TXN_MODE_AUTO }
   let(:loan) { create(:loan, loan_trait, division: division, txn_handling_mode: loan_txn_mode) }
-  let(:described_transaction) { Accounting::Transaction.new(project: loan) }
+  let(:described_transaction) { Accounting::Transaction.new(project: loan, managed: true) }
   subject(:policy) { described_class.new(user, described_transaction) }
 
   shared_examples_for "returns no reasons even if issues other than user role" do
@@ -93,6 +93,18 @@ describe Accounting::TransactionPolicy do
       let(:loan_txn_mode) { Loan::TXN_MODE_READ_ONLY }
       forbid_all_but_read
       it { expect(policy.read_only_reasons).to contain_exactly(:loan_transactions_read_only) }
+    end
+
+    describe "individual transaction level rules" do
+      context "non-ms-managed transaction" do
+        let(:described_transaction) { Accounting::Transaction.new(project: loan, managed: false) }
+        forbid_all_but_read
+      end
+
+      context "ms-managed interest transaction" do
+        let(:described_transaction) { Accounting::Transaction.new(project: loan, managed: false, loan_transaction_type_value: :interest) }
+        forbid_all_but_read
+      end
     end
 
     context "with multiple issues" do


### PR DESCRIPTION
In response to bug 11831, we reviewed spec coverage and the use of 'managed.' The root cause of bug  11831 was that the interest calculator assumes only managed txns are edited or written, but we were allowing admins to edit ANY disbursement or repayment, including non-managed ones. 
This PR restricts editing txn to only managed repayments and disbursements (not unmanaged repayments and disbursements, and no interest txns whether managed or not)