### PR TITLE
11860 sync time stamp seems faulty

### DIFF
--- a/app/controllers/admin/accounting/quickbooks_controller.rb
+++ b/app/controllers/admin/accounting/quickbooks_controller.rb
@@ -30,11 +30,11 @@ class Admin::Accounting::QuickbooksController < Admin::AdminController
       connection_attrs = {
         access_token: response.token,
         invalid_grant: false,
-        last_updated_at: connection.present? ? Time.current : nil,
         refresh_token: response.refresh_token,
         realm_id: params[:realmId],
         division: Division.root,
         token_expires_at: Time.zone.at(response.expires_at)
+        # last_updated_at is not updated, because no new accounting data pulled from qb
       }
       connection ||= Accounting::QB::Connection.new
       connection.update(connection_attrs)

--- a/app/jobs/quickbooks_update_job.rb
+++ b/app/jobs/quickbooks_update_job.rb
@@ -6,7 +6,7 @@ class QuickbooksUpdateJob < QuickbooksJob
     # issues so that if fetch we still hide those loans' txn data appropriately.
     Accounting::SyncIssue.global.delete_all
     self.updater = Accounting::QB::Updater.new
-    started_update_at = Time.zone.current
+    started_update_at = Time.current
     updater.qb_sync_for_loan_update
     task.set_activity_message("syncing_with_quickbooks")
     loans.each_with_index do |loan, index|

--- a/app/jobs/quickbooks_update_job.rb
+++ b/app/jobs/quickbooks_update_job.rb
@@ -37,6 +37,7 @@ class QuickbooksUpdateJob < QuickbooksJob
     # TODO: This is duplicated in Updater#update and needs to be DRYed up.
     # We record last_updated_at as the time this update started. The user-prompted ways
     # the update is started are used by only admins and rarely.
+    Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_update_at}"
     updater.qb_connection.update_attribute(:last_updated_at, started_update_at)
 
     # Even if there have been per-loan errors, we still consider the task completed.

--- a/app/jobs/quickbooks_update_job.rb
+++ b/app/jobs/quickbooks_update_job.rb
@@ -37,7 +37,7 @@ class QuickbooksUpdateJob < QuickbooksJob
     # TODO: This is duplicated in Updater#update and needs to be DRYed up.
     # We record last_updated_at as the time this update started. The user-prompted ways
     # the update is started are used by only admins and rarely.
-    Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_update_at}"
+    Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_update_at}")
     updater.qb_connection.update_attribute(:last_updated_at, started_update_at)
 
     # Even if there have been per-loan errors, we still consider the task completed.

--- a/app/jobs/quickbooks_update_job.rb
+++ b/app/jobs/quickbooks_update_job.rb
@@ -6,6 +6,7 @@ class QuickbooksUpdateJob < QuickbooksJob
     # issues so that if fetch we still hide those loans' txn data appropriately.
     Accounting::SyncIssue.global.delete_all
     self.updater = Accounting::QB::Updater.new
+    started_update_at = Time.zone.current
     updater.qb_sync_for_loan_update
     task.set_activity_message("syncing_with_quickbooks")
     loans.each_with_index do |loan, index|
@@ -34,14 +35,9 @@ class QuickbooksUpdateJob < QuickbooksJob
     end
 
     # TODO: This is duplicated in Updater#update and needs to be DRYed up.
-    # We record last_updated_at as the time the update *finishes* because last_updated_at
-    # is used to avoid runs that immediately follow each other as in the case of a transaction creation
-    # followed by a transaction listing. If we record the time the update *started* and the update
-    # takes some time, we would need to increase the MIN_TIME_BETWEEN_UPDATES value and that might
-    # make it frustrating for users who want to deliberately re-run the updater.
-    # The other function of last_updated_at is to check if a full sync needs to be run,
-    # but that condition is measured in days, not seconds, so this small a difference shouldn't matter.
-    updater.qb_connection.update_attribute(:last_updated_at, Time.current)
+    # We record last_updated_at as the time this update started. The user-prompted ways
+    # the update is started are used by only admins and rarely.
+    updater.qb_connection.update_attribute(:last_updated_at, started_update_at)
 
     # Even if there have been per-loan errors, we still consider the task completed.
     # If there were per-loan errors that support team needs to be notified of, those notices get sent when

--- a/app/jobs/quickbooks_update_job.rb
+++ b/app/jobs/quickbooks_update_job.rb
@@ -33,12 +33,7 @@ class QuickbooksUpdateJob < QuickbooksJob
         notify_of_error(e, data: {context: "Unhandled error during loan update", loan_id: loan.id})
       end
     end
-
-    # TODO: This is duplicated in Updater#update and needs to be DRYed up.
-    # We record last_updated_at as the time this update started. The user-prompted ways
-    # the update is started are used by only admins and rarely.
-    Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_update_at}")
-    updater.qb_connection.update_attribute(:last_updated_at, started_update_at)
+    updater.qb_connection.update_last_updated_at(started_update_at)
 
     # Even if there have been per-loan errors, we still consider the task completed.
     # If there were per-loan errors that support team needs to be notified of, those notices get sent when

--- a/app/models/accounting/qb/connection.rb
+++ b/app/models/accounting/qb/connection.rb
@@ -73,8 +73,8 @@ class Accounting::QB::Connection < ApplicationRecord
       self.access_token = refreshed[:access_token]
       self.refresh_token = refreshed[:refresh_token]
       self.token_expires_at = Time.zone.at(refreshed[:expires_at])
-      self.last_updated_at = Time.current
       self.invalid_grant = false
+      # last_updated_at is not updated, because no new accounting data pulled from qb
       self.save!
       log_token_info("Successfully refreshed token")
       return true

--- a/app/models/accounting/qb/connection.rb
+++ b/app/models/accounting/qb/connection.rb
@@ -44,6 +44,11 @@ class Accounting::QB::Connection < ApplicationRecord
     Rails.logger.tagged(QB_AUTH_LOG_TAG) { Rails.logger.debug("#{message}:\n #{token_info}") }
   end
 
+  def update_last_updated_at(timestamp)
+    Rails.logger.debug("Setting qb cnxn last_updated_at to #{timestamp}")
+    self.update_attribute(:last_updated_at, timestamp)
+  end
+
   private
 
   def expired?
@@ -54,6 +59,7 @@ class Accounting::QB::Connection < ApplicationRecord
       false
     end
   end
+
 
   def refresh_token!
     log_token_info("About to refresh token")

--- a/app/models/accounting/qb/connection.rb
+++ b/app/models/accounting/qb/connection.rb
@@ -46,7 +46,7 @@ class Accounting::QB::Connection < ApplicationRecord
 
   def update_last_updated_at(timestamp)
     Rails.logger.debug("Setting qb cnxn last_updated_at to #{timestamp}")
-    self.update_attribute(:last_updated_at, timestamp)
+    self.update(last_updated_at: timestamp)
   end
 
   private

--- a/app/models/accounting/qb/full_fetcher.rb
+++ b/app/models/accounting/qb/full_fetcher.rb
@@ -30,7 +30,7 @@ module Accounting
       private
 
       def fetch_qb_data
-        started_fetch_at = Time.current
+        started_fetch_at = Time.zone.current
         ::Accounting::QB::TransactionClassFinder.new(division).find_by_name(::Accounting::Transaction::QB_PARENT_CLASS)
         ::Accounting::QB::CustomerFetcher.new(division).fetch
         ::Accounting::QB::AccountFetcher.new(division).fetch

--- a/app/models/accounting/qb/full_fetcher.rb
+++ b/app/models/accounting/qb/full_fetcher.rb
@@ -30,7 +30,7 @@ module Accounting
       private
 
       def fetch_qb_data
-        started_fetch_at = Time.zone.current
+        started_fetch_at = Time.current
         ::Accounting::QB::TransactionClassFinder.new(division).find_by_name(::Accounting::Transaction::QB_PARENT_CLASS)
         ::Accounting::QB::CustomerFetcher.new(division).fetch
         ::Accounting::QB::AccountFetcher.new(division).fetch

--- a/app/models/accounting/qb/full_fetcher.rb
+++ b/app/models/accounting/qb/full_fetcher.rb
@@ -37,8 +37,7 @@ module Accounting
         ::Accounting::QB::TransactionFetcher.new(division).fetch
         ::Accounting::QB::DepartmentFetcher.new(division).fetch
         ::Accounting::QB::VendorFetcher.new(division).fetch
-        Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_fetch_at}")
-        qb_connection.update_attribute(:last_updated_at, started_fetch_at)
+        qb_connection.update_last_updated_at(started_fetch_at)
       rescue StandardError => error
         delete_qb_data
         clear_division_accounts

--- a/app/models/accounting/qb/full_fetcher.rb
+++ b/app/models/accounting/qb/full_fetcher.rb
@@ -37,7 +37,7 @@ module Accounting
         ::Accounting::QB::TransactionFetcher.new(division).fetch
         ::Accounting::QB::DepartmentFetcher.new(division).fetch
         ::Accounting::QB::VendorFetcher.new(division).fetch
-        Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_fetch_at}"
+        Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_fetch_at}")
         qb_connection.update_attribute(:last_updated_at, started_fetch_at)
       rescue StandardError => error
         delete_qb_data

--- a/app/models/accounting/qb/full_fetcher.rb
+++ b/app/models/accounting/qb/full_fetcher.rb
@@ -37,6 +37,7 @@ module Accounting
         ::Accounting::QB::TransactionFetcher.new(division).fetch
         ::Accounting::QB::DepartmentFetcher.new(division).fetch
         ::Accounting::QB::VendorFetcher.new(division).fetch
+        Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_fetch_at}"
         qb_connection.update_attribute(:last_updated_at, started_fetch_at)
       rescue StandardError => error
         delete_qb_data

--- a/app/models/accounting/qb/full_fetcher.rb
+++ b/app/models/accounting/qb/full_fetcher.rb
@@ -97,7 +97,7 @@ module Accounting
 
       def restore_department_associations!(department_division_map)
         Accounting::QB::Department.find_each do |d|
-          d.update_attribute(:division_id, department_division_map[d.qb_id])
+          d.update(division_id: department_division_map[d.qb_id])
         end
       end
     end

--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -34,6 +34,7 @@ module Accounting
         # TODO: This is duplicated in QuickbooksUpdateJob and needs to be DRYed up.
         # We record last_updated_at as the time this update started. The user-prompted ways
         # the update is started are used by only admins and rarely.
+        Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_update_at}"
         qb_connection.update_attribute(:last_updated_at, started_update_at)
       end
 
@@ -112,11 +113,11 @@ module Accounting
 
       def changes
         # assumes that after a new qb connection has been established, the FullFetcher will
-        # retrieve all data from qb and last_updated_at will have a value before updater runs.  
+        # retrieve all data from qb and last_updated_at will have a value before updater runs.
         unless last_updated_at && last_updated_at > max_updated_at
           raise DataResetRequiredError
         end
-
+        Rails.logger.debug("Calling to QB API to get changes since #{last_updated_at}")
         service.since(types, last_updated_at).all_types
       end
 

--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -22,7 +22,7 @@ module Accounting
         # Delete only global issues now before fetch phase but keep loan-specific
         # issues so that if fetch fails we still hide those loans' txn data appropriately.
         Accounting::SyncIssue.global.delete_all
-        started_update_at = Time.zone.current
+        started_update_at = Time.current
         qb_sync_for_loan_update
         if loans
           # check if loan is one object or multiple

--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -7,7 +7,7 @@ module Accounting
     class Updater
       attr_reader :qb_connection
 
-      MIN_TIME_BETWEEN_UPDATES = 5.seconds
+      MIN_TIME_BETWEEN_UPDATES = 5.minutes
 
       def initialize(qb_connection = Division.root.qb_connection)
         @qb_connection = qb_connection

--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -34,7 +34,7 @@ module Accounting
         # TODO: This is duplicated in QuickbooksUpdateJob and needs to be DRYed up.
         # We record last_updated_at as the time this update started. The user-prompted ways
         # the update is started are used by only admins and rarely.
-        Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_update_at}"
+        Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_update_at}")
         qb_connection.update_attribute(:last_updated_at, started_update_at)
       end
 

--- a/app/models/accounting/qb/updater.rb
+++ b/app/models/accounting/qb/updater.rb
@@ -31,11 +31,7 @@ module Accounting
             update_loan(loan)
           end
         end
-        # TODO: This is duplicated in QuickbooksUpdateJob and needs to be DRYed up.
-        # We record last_updated_at as the time this update started. The user-prompted ways
-        # the update is started are used by only admins and rarely.
-        Rails.logger.debug("Setting qb cnxn last_updated_at to #{started_update_at}")
-        qb_connection.update_attribute(:last_updated_at, started_update_at)
+        qb_connection.update_last_updated_at(started_update_at)
       end
 
       # Fetches all changes from Quickbooks since the last update.

--- a/app/models/project_step.rb
+++ b/app/models/project_step.rb
@@ -137,7 +137,7 @@ class ProjectStep < TimelineEntry
   end
 
   def set_completed!(date)
-    update_attribute(:actual_end_date, date)
+    update(:actual_end_date, date)
   end
 
   def completed?
@@ -279,7 +279,7 @@ class ProjectStep < TimelineEntry
     if is_finalized?
       false
     else
-      update_attribute(:is_finalized, true)
+      update(:is_finalized, true)
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -8,7 +8,7 @@ class Task < ApplicationRecord
 
   def enqueue(job_params: {})
     job = job_class.constantize.perform_later(job_params.merge(task_id: id))
-    self.update_attribute(:provider_job_id, job.provider_job_id)
+    self.update(provider_job_id: job.provider_job_id)
     self
   end
 
@@ -36,16 +36,16 @@ class Task < ApplicationRecord
   end
 
   def start!
-    self.update_attribute(:job_first_started_at, Time.current) if self.job_first_started_at.nil?
+    self.update(job_first_started_at: Time.current) if self.job_first_started_at.nil?
     self.increment(:num_attempts).save
   end
 
   def finish!
-    self.update_attribute(:job_succeeded_at, Time.current)
+    self.update(job_succeeded_at: Time.current)
   end
 
   def fail!
-    self.update_attribute(:job_last_failed_at, Time.current)
+    self.update(job_last_failed_at: Time.current)
   end
 
   def succeeded?

--- a/spec/models/accounting/qb/full_fetcher_spec.rb
+++ b/spec/models/accounting/qb/full_fetcher_spec.rb
@@ -94,7 +94,7 @@ describe Accounting::QB::FullFetcher, type: :model do
         .and_return(qb_transaction_service)
       expect(transaction_fetcher).to receive(:fetch).and_call_original
 
-      expect(qb_connection).to receive :update_attribute
+      expect(qb_connection).to receive :update
 
       subject.fetch_all
       division = Division.root
@@ -151,7 +151,7 @@ describe Accounting::QB::FullFetcher, type: :model do
           .and_return(qb_transaction_service)
         expect(transaction_fetcher).to receive(:fetch).and_call_original
 
-        expect(qb_connection).to receive :update_attribute
+        expect(qb_connection).to receive :update
 
         subject.fetch_all
         division = Division.root

--- a/spec/models/accounting/qb/updater_spec.rb
+++ b/spec/models/accounting/qb/updater_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Accounting::QB::Updater, type: :model do
     let(:last_updated_at) { 100.years.ago }
 
     before do
-      division.qb_connection.update_attribute(:last_updated_at, last_updated_at)
+      division.qb_connection.update(last_updated_at: last_updated_at)
     end
 
     context "when last_updated_at is very old" do

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -186,7 +186,7 @@ describe Loan, type: :model do
         context 'update to field other than updated_at' do
           it 'enqueues loan health check' do
             ActiveJob::Base.queue_adapter = :test
-            expect { loan.update_attribute(:projected_end_date, Time.zone.today) }.to have_enqueued_job(RecalculateLoanHealthJob)
+            expect { loan.update(projected_end_date: Time.zone.today) }.to have_enqueued_job(RecalculateLoanHealthJob)
           end
         end
 

--- a/spec/system/admin/accounting/transaction_flow_spec.rb
+++ b/spec/system/admin/accounting/transaction_flow_spec.rb
@@ -127,7 +127,7 @@ describe "transaction flow", :accounting do
           let!(:loan) { create(:loan, :completed, division: division) }
 
           before do
-            Division.root.update_attribute(:qb_read_only, true)
+            Division.root.update(qb_read_only: true)
           end
 
           context "as admin" do


### PR DESCRIPTION
I added logging where last_updated_at is updated, and made it simpler to reason about. 

Main logic changes:
- do not update last_updated_at unless new accounting data is being pulled in (so NOT on authentication updates to teh connection object)
- when updating last_updated_at, always use timestamp from just before the update process (instead of after the update process finishes)