### PR TITLE
Remove confusing current_division method

### DIFF
--- a/app/controllers/admin/accounting/quickbooks_controller.rb
+++ b/app/controllers/admin/accounting/quickbooks_controller.rb
@@ -46,7 +46,7 @@ class Admin::Accounting::QuickbooksController < Admin::AdminController
       job_class: QuickbooksFullFetcherJob,
       job_type_value: :full_fetcher,
       activity_message_value: 'fetching_quickbooks_data'
-    ).enqueue(job_params: {division_id: current_division.qb_division.id})
+    ).enqueue(job_params: {division_id: selected_division_or_root.qb_division.id})
 
     flash[:notice] = t('quickbooks.connection.link_message')
     flash[:alert] = t('quickbooks.connection.import_in_progress_message')

--- a/app/controllers/admin/accounting/settings_controller.rb
+++ b/app/controllers/admin/accounting/settings_controller.rb
@@ -2,7 +2,7 @@ class Admin::Accounting::SettingsController < Admin::AdminController
   def show
     authorize :setting
 
-    @division = current_division.root
+    @division = Division.root
     @accounts = ::Accounting::Account.all
     @last_updated_at = @division.qb_connection.last_updated_at if @division.quickbooks_connected?
     @issue_count = ::Accounting::SyncIssue.count
@@ -12,7 +12,7 @@ class Admin::Accounting::SettingsController < Admin::AdminController
   def update
     authorize :setting
 
-    @division = current_division.root
+    @division = Division.root
     if @division.update(settings_params)
       redirect_to admin_accounting_settings_path, notice: I18n.t(:notice_updated)
     else

--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -4,7 +4,7 @@ class Admin::AdminController < ApplicationController
 
   layout 'admin/signed_in'
 
-  helper_method :selected_division_id, :selected_division, :current_division
+  helper_method :selected_division_id, :selected_division, :selected_division_or_root
 
   prepend_before_action :authenticate_user!
   after_action :verify_authorized

--- a/app/controllers/admin/basic_projects_controller.rb
+++ b/app/controllers/admin/basic_projects_controller.rb
@@ -47,7 +47,7 @@ class Admin::BasicProjectsController < Admin::ProjectsController
   end
 
   def new
-    @basic_project = BasicProject.new(division: current_division)
+    @basic_project = BasicProject.new(division: selected_division_or_root)
     authorize @basic_project
     prep_form_vars
   end

--- a/app/controllers/admin/calendar_controller.rb
+++ b/app/controllers/admin/calendar_controller.rb
@@ -1,6 +1,6 @@
 class Admin::CalendarController < Admin::AdminController
   def index
-    @division = current_division
+    @division = selected_division_or_root
     authorize @division
 
     # For now, simply honor the currently selected division even if it changes after calendar view

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -5,7 +5,7 @@ class Admin::DashboardController < Admin::AdminController
   def dashboard
     authorize :dashboard
     @person = Person.find(current_user.profile_id)
-    @division = current_division
+    @division = selected_division_or_root
 
     prep_calendar
     prep_projects_grid_for_current_user

--- a/app/controllers/admin/data_exports_controller.rb
+++ b/app/controllers/admin/data_exports_controller.rb
@@ -6,7 +6,7 @@ class Admin::DataExportsController < Admin::AdminController
       set_export_class_on_new
       @data_export = @export_class.new(
         locale_code: I18n.locale,
-        division: current_division
+        division: selected_division_or_root
       )
     elsif DataExport::DATA_EXPORT_TYPES.count == 1
       redirect_to new_admin_data_export_path(type: DataExport::DATA_EXPORT_TYPES.keys.first)

--- a/app/controllers/admin/divisions_controller.rb
+++ b/app/controllers/admin/divisions_controller.rb
@@ -5,8 +5,8 @@ class Admin::DivisionsController < Admin::AdminController
     redisplay_url = params[:redisplay_url] || root_path
     division_id = params[:division_id]
     save_selected_division_to_session(division_id)
-    division = Division.find_safe(division_id)
-    authorize division || current_division
+    division = Division.find_by(id: division_id) || Division.root
+    authorize division
     redirect_to redisplay_url
   end
 
@@ -46,7 +46,7 @@ class Admin::DivisionsController < Admin::AdminController
   end
 
   def new
-    @division = Division.new(parent: current_division)
+    @division = Division.new(parent: selected_division_or_root)
     authorize @division
     prep_form_vars
   end

--- a/app/controllers/admin/documentations_controller.rb
+++ b/app/controllers/admin/documentations_controller.rb
@@ -9,7 +9,8 @@ class Admin::DocumentationsController < Admin::AdminController
   end
 
   def new
-    @documentation = Documentation.new(html_identifier: params[:html_identifier], division: current_division)
+    @documentation = Documentation.new(html_identifier: params[:html_identifier],
+                                       division: selected_division_or_root)
     authorize @documentation
 
     @previous_url = request.referer
@@ -28,7 +29,7 @@ class Admin::DocumentationsController < Admin::AdminController
 
   def create
     @documentation = Documentation.new(documentation_params)
-    @documentation.division = current_division
+    @documentation.division = selected_division_or_root
     authorize @documentation
 
     if @documentation.save

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -8,8 +8,6 @@ module Admin
     TABS = %w(details questions timeline logs transactions calendar).freeze
 
     def index
-      # Note, current_division is used when creating new entities and is guaranteed to return a value.
-      # selected_division is used for index filtering, and may be unassigned.
       authorize(Loan)
 
       @loans_grid = initialize_grid(
@@ -65,7 +63,8 @@ module Admin
     end
 
     def new
-      @loan = Loan.new(division: current_division, currency: current_division.default_currency)
+      @loan = Loan.new(division: selected_division_or_root,
+                       currency: selected_division_or_root.default_currency)
       @loan.organization_id = params[:organization_id] if params[:organization_id]
       authorize(@loan)
       prep_form_vars
@@ -200,7 +199,7 @@ module Admin
       return if (reasons = policy(@sample_transaction).read_only_reasons).empty?
 
       args = {}
-      args[:current_division] = @loan.division.name
+      args[:selected_division] = @loan.division.name
       args[:qb_division] = @loan.qb_division&.name
       args[:qb_division_settings_link] =
         view_context.link_to(t("common.settings"), admin_division_path(@loan.division))

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -35,7 +35,7 @@ class Admin::OrganizationsController < Admin::AdminController
   end
 
   def new
-    @org = Organization.new(division: current_division)
+    @org = Organization.new(division: selected_division_or_root)
     authorize @org
     prep_form_vars
   end
@@ -54,7 +54,7 @@ class Admin::OrganizationsController < Admin::AdminController
 
   def create
     @org = Organization.new(organization_params)
-    @org.division ||= current_division
+    @org.division ||= selected_division_or_root
     authorize @org
 
     if @org.save

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -37,7 +37,7 @@ module Admin
     end
 
     def new
-      @person = Person.new(division: current_division)
+      @person = Person.new(division: selected_division_or_root)
       authorize @person
       prep_form_vars
     end

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -47,7 +47,7 @@ class Admin::QuestionsController < Admin::AdminController
 
   def move
     target = Question.find(params[:target])
-    QuestionMover.new(current_division: selected_division, question: @question,
+    QuestionMover.new(selected_division: selected_division, question: @question,
                       target: target, relation: params[:relation].to_sym).move
     render_set_json(@question.question_set)
   rescue ArgumentError

--- a/app/controllers/concerns/division_selectable.rb
+++ b/app/controllers/concerns/division_selectable.rb
@@ -1,19 +1,16 @@
 module DivisionSelectable
   extend ActiveSupport::Concern
 
-  # Represents the division to use when creating new entities.
-  def current_division
-    selected_division || default_division
-  end
-
-  # Division to use for new entities if a division is not specifically selected
-  def default_division
-    current_user.default_division
-  end
-
   # Represents the current division filter applied to index views.
+  # Returns NIL if in 'All Divisions' mode.
   def selected_division
-    @selected_division ||= (id = selected_division_id) ? Division.find_safe(id) : nil
+    return @selected_division if defined?(@selected_division)
+
+    @selected_division = selected_division_id ? Division.find(selected_division_id) : nil
+  end
+
+  def selected_division_or_root
+    selected_division || Division.root
   end
 
   # Returns the index grid view conditions filter to be applied.  If a specific division is

--- a/app/controllers/concerns/documentable.rb
+++ b/app/controllers/concerns/documentable.rb
@@ -8,7 +8,7 @@ module Documentable
   def set_documentations
     @documentations_by_html = Documentation.where(
       calling_controller: controller_name, # name of current controller
-      division: current_division.self_and_ancestors # divisions with viewable documentation
+      division: selected_division_or_root.self_and_ancestors # divisions with viewable documentation
     ).index_by(&:html_identifier) # creates a hash
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,11 +7,11 @@ class SessionsController < Devise::SessionsController
   end
 
   def set_to_default_division
-    return unless default_division
- 
-    # Without this check, the headerbar logo will not render
-    return if default_division.id == Division.root_id
+    return unless current_user.default_division
 
-    session[:selected_division_id] = default_division.id
+    # Without this check, the headerbar logo will not render
+    return if current_user.default_division.root?
+
+    session[:selected_division_id] = current_user.default_division_id
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -53,7 +53,7 @@ module AdminHelper
       end
       action_link = link_to icon_tag("pencil"), edit_admin_documentation_path(documentation), id: "#{html_identifier}-edit-link" if policy(documentation).edit?
     else
-      new_documentation = Documentation.new(division: current_division)
+      new_documentation = Documentation.new(division: selected_division_or_root)
       return "" unless policy(new_documentation).new?
       caller_string = "#{controller_name}##{action_name}"
       data_content = t("documentation.no_documentations")

--- a/app/models/legacy/loan_response.rb
+++ b/app/models/legacy/loan_response.rb
@@ -22,7 +22,7 @@ module Legacy
 
       result[:rating] = rating  if rating
       if loan_responses_i_frame_id
-        iframe = LoanResponsesIFrame.find_safe(loan_responses_i_frame_id)
+        iframe = LoanResponsesIFrame.find_by(id: loan_responses_i_frame_id)
         if iframe
           iframe.parse_legacy_display_data
           result[:url] = iframe.original_url

--- a/app/models/legacy/project_log.rb
+++ b/app/models/legacy/project_log.rb
@@ -14,7 +14,7 @@ module Legacy
     def migrated_loan
       # beware the legacy db has inconsistent casing of the project table name
       if project_table.downcase == 'loans'
-        result = ::Loan.find_safe(project_id)
+        result = ::Loan.find_by(id: project_id)
         unless result
           #JE todo: send warnings also to separate log
           $stderr.puts "WARNING: ignoring ProjectLog[#{id}] pointing to invalid Loan ID: #{project_id}"

--- a/app/models/question_mover.rb
+++ b/app/models/question_mover.rb
@@ -3,12 +3,12 @@
 class QuestionMover
   include ActiveModel::Model
 
-  attr_accessor :current_division, :question, :target, :relation
+  attr_accessor :selected_division, :question, :target, :relation
 
   def move
     raise ArgumentError, "invalid relation" unless %i[before after inside].include?(relation)
 
-    ensure_current_division
+    ensure_selected_division
     ensure_new_parent_is_group
     ensure_correct_adjacency
     ensure_parent_of_same_or_ancestor_division
@@ -39,8 +39,8 @@ class QuestionMover
     siblings.any? { |s| s.division_id == question.division_id }
   end
 
-  def ensure_current_division
-    raise ArgumentError, "must be in current division" unless question.division_id == current_division.id
+  def ensure_selected_division
+    raise ArgumentError, "must be in current division" unless question.division_id == selected_division.id
   end
 
   def ensure_new_parent_is_group

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
   def accessible_division_ids
     base_ids = roles.where(resource_type: :Division, name: [:member, :admin]).pluck(:resource_id).uniq
     all_ids = base_ids.map do |id|
-      division = Division.find_safe(id)
+      division = Division.find_by(id: id)
       division.self_and_descendants.pluck(:id) if division
     end
     all_ids.flatten.uniq.compact
@@ -47,7 +47,7 @@ class User < ApplicationRecord
   end
 
   # Require a user to have access to at least some division in order to login.
-  # Note, this avoids needing to worry about a nil current_division in the controller logic.
+  # Note, this avoids needing to worry about a nil selected_division in the controller logic.
   def active_for_authentication?
     profile && profile.has_system_access? && self.accessible_division_ids.present?
   end

--- a/config/initializers/active_record_base.rb
+++ b/config/initializers/active_record_base.rb
@@ -4,12 +4,6 @@
 
 
 class ActiveRecord::Base
-
-  # fetch a single record or return nil if doesn't exist
-  def self.find_safe(id)
-    self.where(id: id).first
-  end
-
   # will update the postgres sequence value to be greater than the highest existing id plus a gap
   # gap - gap in id values to leave between existing highest id and next value
   def self.recalibrate_sequence(gap: 0, id: nil)

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -394,7 +394,7 @@ en:
       qb_not_connected_html: "QuickBooks is not connected"
       accounts_not_selected_html: "QuickBooks accounts are not selected on the division '%{qb_division}' (see %{accounting_settings_link})"
       division_transactions_read_only_html: "transactions are in read-only mode for the division '%{qb_division}' (see %{accounting_settings_link})"
-      department_not_set_html: "the QB department is not set on the division '%{current_division}' (see %{qb_division_settings_link})"
+      department_not_set_html: "the QB department is not set on the division '%{selected_division}' (see %{qb_division_settings_link})"
       loan_not_active_html: "this loan is not active"
       loan_transactions_read_only_html: "transactions are in read-only mode for this loan"
     there_are_issues:

--- a/spec/models/question_mover_spec.rb
+++ b/spec/models/question_mover_spec.rb
@@ -50,7 +50,7 @@ describe QuestionMover do
   # rubocop:enable Layout/IndentationConsistency
 
   subject(:mover) do
-    QuestionMover.new(current_division: current_division, question: question,
+    QuestionMover.new(selected_division: selected_division, question: question,
                       target: target, relation: relation)
   end
 
@@ -86,7 +86,7 @@ describe QuestionMover do
   context "moving question with current division" do
     context "within same parent" do
       context "to top of division block" do
-        let(:current_division) { div_c1 }
+        let(:selected_division) { div_c1 }
         let(:question) { q114 }
         let(:target) { q113 }
         let(:relation) { :before }
@@ -94,7 +94,7 @@ describe QuestionMover do
       end
 
       context "to bottom of division block" do
-        let(:current_division) { div_c1 }
+        let(:selected_division) { div_c1 }
         let(:question) { q113 }
         let(:target) { q115 }
         let(:relation) { :after }
@@ -102,7 +102,7 @@ describe QuestionMover do
       end
 
       context "outside of division block" do
-        let(:current_division) { div_c1 }
+        let(:selected_division) { div_c1 }
         let(:question) { q113 }
         let(:target) { q116 }
         let(:relation) { :after }
@@ -113,7 +113,7 @@ describe QuestionMover do
 
     context "to different parent" do
       context "to non-group" do
-        let(:current_division) { div_c1 }
+        let(:selected_division) { div_c1 }
         let(:question) { q113 }
         let(:target) { q114 }
         let(:relation) { :inside }
@@ -122,7 +122,7 @@ describe QuestionMover do
       end
 
       context "to parent with lower division" do
-        let(:current_division) { div_a }
+        let(:selected_division) { div_a }
         let(:question) { q2 }
         let(:target) { q4 }
         let(:relation) { :inside }
@@ -133,7 +133,7 @@ describe QuestionMover do
       context "to parent with ancestor division" do
         context "when existing division block exists" do
           context "within existing division block :after target with same division" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q113 }
             let(:relation) { :after }
@@ -141,7 +141,7 @@ describe QuestionMover do
           end
 
           context "within existing division block :after target with different division" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q112 } # has div_c3
             let(:relation) { :after }
@@ -149,7 +149,7 @@ describe QuestionMover do
           end
 
           context "within existing division block :before target with different division" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q116 } # has div_c3
             let(:relation) { :before }
@@ -157,7 +157,7 @@ describe QuestionMover do
           end
 
           context "within existing division block with :inside" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q115 }
             let(:target) { q6 }
             let(:relation) { :inside }
@@ -165,7 +165,7 @@ describe QuestionMover do
           end
 
           context "outside existing division block with :before" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q112 }
             let(:relation) { :before }
@@ -174,7 +174,7 @@ describe QuestionMover do
           end
 
           context "outside existing division block with :before at start of siblings" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q110 }
             let(:relation) { :before }
@@ -183,7 +183,7 @@ describe QuestionMover do
           end
 
           context "outside existing division block with :after" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q116 }
             let(:relation) { :after }
@@ -192,7 +192,7 @@ describe QuestionMover do
           end
 
           context "outside existing division block with :after at end of siblings" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q119 }
             let(:relation) { :after }
@@ -201,7 +201,7 @@ describe QuestionMover do
           end
 
           context "outside existing division block with :inside" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q115 }
             let(:target) { q4 }
             let(:relation) { :inside }
@@ -212,7 +212,7 @@ describe QuestionMover do
 
         context "when no questions of same division but some of same division depth" do
           context "within existing division depth block adjacent to other division blocks" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q103 }
             let(:relation) { :after }
@@ -220,7 +220,7 @@ describe QuestionMover do
           end
 
           context "within existing division depth block inside other division block" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q102 }
             let(:relation) { :after }
@@ -228,7 +228,7 @@ describe QuestionMover do
           end
 
           context "before existing division depth block with :inside" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q10 }
             let(:relation) { :inside }
@@ -237,7 +237,7 @@ describe QuestionMover do
           end
 
           context "before existing division depth block with :before" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q41 }
             let(:target) { q100 }
             let(:relation) { :before }
@@ -246,7 +246,7 @@ describe QuestionMover do
           end
 
           context "after existing division depth block with :before" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q113 }
             let(:target) { q105 }
             let(:relation) { :before }
@@ -255,7 +255,7 @@ describe QuestionMover do
           end
 
           context "after existing division depth block with :after" do
-            let(:current_division) { div_c1 }
+            let(:selected_division) { div_c1 }
             let(:question) { q113 }
             let(:target) { q105 }
             let(:relation) { :after }
@@ -266,7 +266,7 @@ describe QuestionMover do
 
         context "when no questions of same division depth" do
           context "at end of group" do
-            let(:current_division) { div_d }
+            let(:selected_division) { div_d }
             let(:question) { q118 }
             let(:target) { q11 }
             let(:relation) { :after }
@@ -274,7 +274,7 @@ describe QuestionMover do
           end
 
           context "not at end of group" do
-            let(:current_division) { div_d }
+            let(:selected_division) { div_d }
             let(:question) { q118 }
             let(:target) { q11 }
             let(:relation) { :before }
@@ -285,7 +285,7 @@ describe QuestionMover do
 
         context "when group is empty" do
           context "at end of group" do
-            let(:current_division) { div_d }
+            let(:selected_division) { div_d }
             let(:question) { q118 }
             let(:target) { q7 }
             let(:relation) { :inside }
@@ -297,7 +297,7 @@ describe QuestionMover do
   end
 
   context "moving question with ancestor division than current division" do
-    let(:current_division) { div_d }
+    let(:selected_division) { div_d }
     let(:question) { q114 }
     let(:target) { q113 }
     let(:relation) { :before }
@@ -306,7 +306,7 @@ describe QuestionMover do
   end
 
   context "moving question with lower division than current division" do
-    let(:current_division) { div_a }
+    let(:selected_division) { div_a }
     let(:question) { q114 }
     let(:target) { q113 }
     let(:relation) { :before }

--- a/spec/support/helpers/system_spec_helpers.rb
+++ b/spec/support/helpers/system_spec_helpers.rb
@@ -26,7 +26,16 @@ module SystemSpecHelpers
     have_css("#{container} .alert", text: msg)
   end
 
-  def select_division(division_name)
+  def select_division(division_or_name)
+    division_name =
+      if division_or_name.is_a?(String)
+        division_or_name
+      elsif division_or_name.root?
+        "All Divisions"
+      else
+        division_or_name.name
+      end
+
     within('.user-div-info') do
       find('[data-expands="division-dropdown"]').click
       find('.select_division_form').select(division_name)

--- a/spec/support/shared_examples/flow.rb
+++ b/spec/support/shared_examples/flow.rb
@@ -8,19 +8,6 @@ shared_examples "flow" do
   scenario 'can index/show/edit and change division', js: true do
     visit(polymorphic_path([:admin,subject.class]))
 
-    # Make sure we can change divisions
-    expect(find('[data-expands="division-dropdown"]')).to have_content 'Select Division'
-
-    # Change to specific division, and ensure the page reloads properly
-    select_division(division.name)
-    expect(find('[data-expands="division-dropdown"]')).to have_content 'Change Division'
-    expect(find('.without-logo')).to have_content division.name
-
-    # Change back to all divisions, and ensure it reloads properly
-    select_division('All Divisions')
-    expect(find('.madeline')).to have_content 'Madeline'
-    expect(find('[data-expands="division-dropdown"]')).to have_content 'Select Division'
-
     # Now test index/show/edit
     expect(page).to have_content(subject.name)
 

--- a/spec/system/admin/basic_project_flow_spec.rb
+++ b/spec/system/admin/basic_project_flow_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
-describe 'basic project flow' do
+describe 'basic project flow', js: true do
 
-  let(:division) { create(:division) }
-  let(:user) { create_member(division) }
+  let!(:division) { create(:division) }
+  let!(:user) { create_member(division) }
   let!(:basic_project) { create(:basic_project, division: division) }
-  let(:parent_group) { create(:project_group) }
+  let!(:parent_group) { create(:project_group) }
   let!(:child_group) { create(:project_group, project: basic_project, parent: parent_group) }
 
   before do
     login_as(user, scope: :user)
+    visit("/")
+    select_division(division)
   end
 
   include_examples "flow" do
@@ -28,6 +30,7 @@ describe 'basic project flow' do
   scenario 'validations for updating basic project' do
     visit admin_basic_projects_path
     click_on basic_project.id.to_s
+    find('.edit-action').click
     select user.name, from: 'basic_project_primary_agent_id'
     select user.name, from: 'basic_project_secondary_agent_id'
     click_on 'Update Basic project'
@@ -36,13 +39,13 @@ describe 'basic project flow' do
 
   scenario 'loan with groups can be deleted' do
     visit admin_basic_project_path(basic_project)
-    click_on 'Delete Project'
+    accept_confirm { click_on 'Delete Project' }
     expect(page).to have_content('Record was successfully deleted')
   end
 
   scenario 'project with groups can be duplicated' do
     visit admin_basic_project_path(basic_project)
-    click_on 'Duplicate Project'
+    accept_confirm { click_on 'Duplicate Project' }
     expect(page).to have_content('The project was successfully duplicated.')
     expect(page).to have_content("Copy of #{basic_project.name}")
   end

--- a/spec/system/admin/loan_flow_spec.rb
+++ b/spec/system/admin/loan_flow_spec.rb
@@ -1,14 +1,16 @@
 require "rails_helper"
 
 describe "loan flow", js: true do
-  let(:division) { create(:division) }
-  let(:user) { create_member(division) }
+  let!(:division) { create(:division) }
+  let!(:user) { create_member(division) }
   let!(:loan) { create(:loan, division: division) }
-  let(:parent_group) { create(:project_group) }
+  let!(:parent_group) { create(:project_group) }
   let!(:child_group) { create(:project_group, project: loan, parent: parent_group) }
 
   before do
     login_as(user, scope: :user)
+    visit("/")
+    select_division(division)
   end
 
   # This should work, but for some reason it fails a lot more often

--- a/spec/system/admin/organization_flow_spec.rb
+++ b/spec/system/admin/organization_flow_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'organization flow' do
+describe 'organization flow', js: true do
   let(:currency) { create(:currency) }
   let(:division) { create(:division, currency_id: currency.id) }
   let(:admin) { create_admin(division) }
@@ -24,6 +24,9 @@ describe 'organization flow' do
 
     # login as user
     login_as(user, scope: :user)
+
+    visit("/")
+    select_division(division)
 
     option_set = Loan.public_level_option_set
     option_set.options.create(value: 'public', label_translations: { en: 'Public' })


### PR DESCRIPTION
`current_division` is a very confusing method since it returns the user's "owning division" if selected_division is nil, which means the Root Division/'All Divisions' is selected.

In the prod db, there are 3 users who have access to the root division but do not have it as their 'owning division'. So for those three users, if they have 'All Divisions' selected, some strange things would happen.

I think devs generally think `current_division` means you'll get a division object back, including root if you've selected root. So I saw it used in a bunch of places where I think dev intention was not to get the user's owning division when in root div mode. 

So I think it's best to remove the method entirely and replace with selected_division_or_root. I went through and tried to guess developer intent as best I could.

Ultimately I'd like to remove selected_division altogether and rename selected_division_or_root to current_division, as I think it's an anti-pattern to return `nil` in that way. It's much better to use the root division object itself as it leads to fewer nil errors. But for now, given that selected_division still exists, using current_division is always going to be confusing b/c it's not clear what the difference is between it and selected_division.