### PR TITLE
11923 prevent dup response sets

### DIFF
--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -1,3 +1,5 @@
+# Note: loan duplication happens under project duplication
+
 class Loan < Project
   include MediaAttachable
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,10 +36,17 @@ class Project < ApplicationRecord
     enable
     propagate
     exclude_association :media
+    # timeline excluded here bc done manually in project_duplicator.rb
     exclude_association :timeline_entries
-    exclude_association :transactions
     exclude_association :copies
+    exclude_association :transactions
     exclude_association :sync_issues
+    # below we exclude criteria and post analysis associations (see loan.rb) because they refer
+    # to the same objects as the response_set association on a loan
+    # if we don't exclude these two, then amoeba attempts to copy any criteria
+    # or post_analysis response set twice
+    exclude_association :criteria
+    exclude_association :post_analysis
 
     # The default name is computed, if it hasn't been set it will be blank.
     # We need to manually copy over the name and set it here for it to work.

--- a/app/views/admin/loans/_details.html.slim
+++ b/app/views/admin/loans/_details.html.slim
@@ -17,12 +17,12 @@ section.loan-fields data-container='details' class=(@loan.valid? ? 'show-view' :
       i.fa.fa-trash.fa-large>
       = t("loan.delete")
 
-    / Duplicate
-    / - if @loan.valid?
-    /   = link_to duplicate_admin_loan_path,
-    /     data: { confirm: t("loan.confirm_duplication") }
-    /     i.fa.fa-clone>
-    /     = t("loan.duplicate")
+      / Duplicate
+    - if @loan.valid?
+      = link_to duplicate_admin_loan_path,
+        data: { confirm: t("loan.confirm_duplication") }
+        i.fa.fa-clone>
+        = t("loan.duplicate")
 
     / Open Transactions - Old System
     - if policy(@loan).old_system_access?

--- a/spec/factories/loans_factory.rb
+++ b/spec/factories/loans_factory.rb
@@ -162,20 +162,15 @@ FactoryBot.define do
       end
     end
 
-    trait :with_copies do
-      after(:create) do |loan|
-        create(:loan, original: loan)
-      end
-    end
-
     # Assumes a LoanQuestionSet with name 'loan_criteria' and questions `summary` and `workers` exists.
     trait :with_criteria_responses do |loan|
       after(:create) do |loan|
-        loan.criteria = create(:response_set,
+        create(:response_set,
           kind: 'criteria',
           loan: loan,
           custom_data: {summary: 'foo', workers: 5}
         )
+
       end
     end
   end

--- a/spec/models/project_duplicator_spec.rb
+++ b/spec/models/project_duplicator_spec.rb
@@ -1,10 +1,10 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ProjectDuplicator, type: :model do
   subject(:duplicator) { described_class.new(loan) }
   let(:loan) { create(:loan) }
 
-  it 'copies proper columns' do
+  it "copies proper columns" do
     new_loan = duplicator.duplicate
 
     attribs_to_exclude = %w(id created_at updated_at name original_id)
@@ -12,8 +12,8 @@ RSpec.describe ProjectDuplicator, type: :model do
       .to eq loan.attributes.except(*attribs_to_exclude)
   end
 
-  context 'with default name' do
-    let(:loan) { create(:loan, name: '') }
+  context "with default name" do
+    let(:loan) { create(:loan, name: "") }
 
     it 'name column is prepended with "Copy of"' do
       new_loan = duplicator.duplicate
@@ -22,7 +22,7 @@ RSpec.describe ProjectDuplicator, type: :model do
     end
   end
 
-  context 'with non-default name' do
+  context "with non-default name" do
     it 'name column is prepended with "Copy of"' do
       new_loan = duplicator.duplicate
 
@@ -30,7 +30,7 @@ RSpec.describe ProjectDuplicator, type: :model do
     end
   end
 
-  context 'with populated associations' do
+  context "with populated associations" do
     let(:loan) do
       create(:loan, :with_loan_media, :with_timeline, :with_accounting_transaction)
     end
@@ -39,17 +39,17 @@ RSpec.describe ProjectDuplicator, type: :model do
     # Using #reload does not do it.
     let(:new_loan) { Loan.find(duplicator.duplicate.id) }
 
-    it 'ignores media' do
+    it "ignores media" do
       expect(new_loan.media.count).to eq 0
     end
 
-    it 'copies timeline_entries' do
+    it "copies timeline_entries" do
       expect(new_loan.timeline_entries[0].id).not_to eq loan.timeline_entries[0].id
       expect(new_loan.timeline_entries.count).to eq loan.timeline_entries.count
       expect(TimelineEntry.where(project_id: new_loan.id, parent_id: nil).count).to eq 1
     end
 
-    it 'copies timeline_entry children' do
+    it "copies timeline_entry children" do
       root = loan.root_timeline_entry
       new_root = new_loan.root_timeline_entry
 
@@ -61,19 +61,19 @@ RSpec.describe ProjectDuplicator, type: :model do
       expect(new_root.c[1].c.count).to eq root.c[1].c.count
     end
 
-    it 'copies health_check' do
+    it "copies health_check" do
       expect(new_loan.health_check.loan_id).to eq new_loan.id
     end
 
-    it 'ignores transactions' do
+    it "ignores transactions" do
       expect(new_loan.transactions.count).to eq 0
     end
 
-    it 'ignores copies' do
+    it "ignores copies" do
       expect(new_loan.copies.count).to eq 0
     end
 
-    context 'with project logs' do
+    context "with project logs" do
       before do
         grandchild = loan.root_timeline_entry.c[0].c[0]
         logs = create_list(:project_log, 2, project_step: grandchild)
@@ -81,7 +81,7 @@ RSpec.describe ProjectDuplicator, type: :model do
         loan.save!
       end
 
-      it 'copies project logs' do
+      it "copies project logs" do
         log = loan.project_logs[0]
         new_log = new_loan.project_logs[0]
 
@@ -93,7 +93,7 @@ RSpec.describe ProjectDuplicator, type: :model do
     end
   end
 
-  context 'with scheduled children' do
+  context "with scheduled children" do
     # Creates a timeline and returns nodes stored in a hash.
     let!(:nodes) { ProjectGroupFactoryHelper.create_full_timeline }
     let(:loan) { nodes[:root].project }
@@ -113,8 +113,8 @@ RSpec.describe ProjectDuplicator, type: :model do
       g5_s1.update!(schedule_parent_id: g3_s3.id)
     end
 
-    shared_examples_for 'scheduled loan' do
-      it 'has been properly scheduled' do
+    shared_examples_for "scheduled loan" do
+      it "has been properly scheduled" do
         # We need to rebuild these references because we're using these examples for both
         # the old and the new loan.
         root = subject.root_timeline_entry
@@ -122,38 +122,38 @@ RSpec.describe ProjectDuplicator, type: :model do
         g3_s3 = root.c[2].c[2]
         g5_s1 = root.c[5].c[0]
 
-        expect(s1.scheduled_start_date).to eq Date.parse('2017-02-28')
+        expect(s1.scheduled_start_date).to eq Date.parse("2017-02-28")
         expect(s1.scheduled_duration_days).to eq 30
         expect(s1.schedule_parent).to be_nil
 
-        expect(g3_s3.scheduled_start_date).to eq Date.parse('2017-03-30')
+        expect(g3_s3.scheduled_start_date).to eq Date.parse("2017-03-30")
         expect(g3_s3.scheduled_duration_days).to eq 5
         expect(g3_s3.schedule_parent).to eq s1
 
         # start date for dependent step is end date of previous step + 1
-        expect(g5_s1.scheduled_start_date).to eq Date.parse('2017-04-04')
+        expect(g5_s1.scheduled_start_date).to eq Date.parse("2017-04-04")
         expect(g5_s1.scheduled_duration_days).to eq 3
         expect(g5_s1.schedule_parent).to eq g3_s3
       end
     end
 
-    context 'original loan' do
+    context "original loan" do
       subject { loan }
-      it_behaves_like 'scheduled loan'
+      it_behaves_like "scheduled loan"
     end
 
-    context 'copied loan' do
+    context "copied loan" do
       subject { Loan.find(duplicator.duplicate.id) }
 
-      it_behaves_like 'scheduled loan'
+      it_behaves_like "scheduled loan"
 
-      it 'has different loan id from original' do
+      it "has different loan id from original" do
         expect(subject.id).not_to eq loan.id
       end
     end
   end
 
-  context 'loan with business planning responses' do
+  context "loan with business planning responses" do
     let!(:criteria_question_set) { create(:question_set, :loan_criteria) }
     let!(:loan) do
       create(:loan, :with_criteria_responses, :with_loan_media, :with_timeline, :with_accounting_transaction)
@@ -161,10 +161,13 @@ RSpec.describe ProjectDuplicator, type: :model do
 
     let!(:new_loan) { Loan.find(duplicator.duplicate.id) }
 
-    it 'makes exactly one copy of criteria responses with matching answers' do
+    it "makes exactly one copy of criteria responses with matching answers" do
       expect(new_loan.response_sets.count).to eq 1
+      # different response set with same data
       expect(new_loan.criteria.id).not_to eq loan.criteria.id
       expect(new_loan.criteria.custom_data).to eq loan.criteria.custom_data
+      # same question set
+      expect(new_loan.criteria.question_set.id).to eq loan.criteria.question_set.id
     end
   end
- end
+end

--- a/spec/models/project_duplicator_spec.rb
+++ b/spec/models/project_duplicator_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe ProjectDuplicator, type: :model do
     it 'copies timeline_entries' do
       expect(new_loan.timeline_entries[0].id).not_to eq loan.timeline_entries[0].id
       expect(new_loan.timeline_entries.count).to eq loan.timeline_entries.count
+      expect(TimelineEntry.where(project_id: new_loan.id, parent_id: nil).count).to eq 1
     end
 
     it 'copies timeline_entry children' do

--- a/spec/models/project_duplicator_spec.rb
+++ b/spec/models/project_duplicator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ProjectDuplicator, type: :model do
 
   context 'with populated associations' do
     let(:loan) do
-      create(:loan, :with_loan_media, :with_timeline, :with_accounting_transaction, :with_copies)
+      create(:loan, :with_loan_media, :with_timeline, :with_accounting_transaction)
     end
 
     # root_timeline_entry children are incorrect on new_loan. Reload it, to bust the cache.
@@ -151,4 +151,19 @@ RSpec.describe ProjectDuplicator, type: :model do
       end
     end
   end
-end
+
+  context 'loan with business planning responses' do
+    let!(:criteria_question_set) { create(:question_set, :loan_criteria) }
+    let!(:loan) do
+      create(:loan, :with_criteria_responses, :with_loan_media, :with_timeline, :with_accounting_transaction)
+    end
+
+    let!(:new_loan) { Loan.find(duplicator.duplicate.id) }
+
+    it 'makes exactly one copy of criteria responses' do
+      expect(new_loan.response_sets.count).to eq 1
+      expect(new_loan.criteria.id).not_to eq loan.criteria.id
+      # check answers match
+    end
+  end
+ end

--- a/spec/models/project_duplicator_spec.rb
+++ b/spec/models/project_duplicator_spec.rb
@@ -160,10 +160,10 @@ RSpec.describe ProjectDuplicator, type: :model do
 
     let!(:new_loan) { Loan.find(duplicator.duplicate.id) }
 
-    it 'makes exactly one copy of criteria responses' do
+    it 'makes exactly one copy of criteria responses with matching answers' do
       expect(new_loan.response_sets.count).to eq 1
       expect(new_loan.criteria.id).not_to eq loan.criteria.id
-      # check answers match
+      expect(new_loan.criteria.custom_data).to eq loan.criteria.custom_data
     end
   end
  end

--- a/spec/system/admin/loan_flow_spec.rb
+++ b/spec/system/admin/loan_flow_spec.rb
@@ -65,7 +65,7 @@ describe "loan flow", js: true do
 
   describe "details" do
     # prevent duplication until extra duplicate response set bug 11923 fully resolved
-    xscenario "can duplicate" do
+    scenario "can duplicate" do
       visit admin_loan_path(loan)
 
       accept_confirm { click_on("Duplicate") }

--- a/spec/system/admin/loan_flow_spec.rb
+++ b/spec/system/admin/loan_flow_spec.rb
@@ -70,6 +70,7 @@ describe "loan flow", js: true do
 
       accept_confirm { click_on("Duplicate") }
       expect(page).to have_content "Copy of #{loan.display_name}"
+      # TODO: continue this scenario to try editing copy's business planning responses two times
     end
 
     describe "old system menu" do


### PR DESCRIPTION
Patch to bring back duplicating loans as a feature. Root issue was that for at least 5 yrs, we have had 'has_one' associations for 'criteria' and 'post_analysis' on the loan model. (see https://github.com/sassafrastech/madeline/commit/bb6f1a401b84e2548918474ece56c039cd10bc99). It creates a bug with amoeba_dup, which we use for duplicating projects and loans (loans are subclass of project) because amoeba_dup for projects is configured (in project.rb) to include all associations that are not explicitly excluded. So it copies once for the 'has_one' criteria line, once for the 'has_one' post_analysis line, and once for the has_many response_sets line. when it copies for the has_many response_sets line, it copies the criteria and post analysis response sets it already saw and copied.

SOLUTION:
exclude criteria and post analysis associations in the amoeba duplication config for project with an explanation. this keeps the change confined to the duplication code instead of doing a change (like replacing the has_ones with getters and setters) that will affect business planning, and may also conflict more with refactor tom is working on.

