### PR TITLE
11958: Add inception field

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -83,7 +83,7 @@ class Admin::OrganizationsController < Admin::AdminController
     params.require(:organization).permit(
       :name, :street_address, :city, :state, :country_id, :neighborhood, :website,
       :alias, :email, :fax, :primary_phone, :secondary_phone, :tax_no,
-      :industry, :sector, :referral_source, :contact_notes,
+      :industry, :sector, :referral_source, :contact_notes, :inception_value,
       :division_id, :primary_contact_id, :legal_name, :postal_code,
       person_ids: []
     )

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,6 +3,7 @@ class Organization < ApplicationRecord
   include Notable
   include MediaAttachable
   include DivisionBased
+  include OptionSettable
 
   belongs_to :division
   belongs_to :country
@@ -10,6 +11,8 @@ class Organization < ApplicationRecord
 
   has_many :loans, dependent: :destroy
   has_many :people, foreign_key: :primary_organization_id, dependent: :nullify
+
+  attr_option_settable :inception
 
   validates :name, :division, :country, presence: true
 

--- a/app/views/admin/organizations/_form.html.slim
+++ b/app/views/admin/organizations/_form.html.slim
@@ -88,6 +88,11 @@
     .view-element = @org.industry
     = f.input_field :industry
 
+  = f.input :inception
+    .view-element = @org.inception_label
+    = f.input_field :inception_value, collection: Organization.inception_options,
+                                      selected: @org.inception_value, include_blank: true
+
   = f.input :referral_source
     .view-element = @org.referral_source
     = f.input_field :referral_source

--- a/app/views/admin/organizations/_organizations_grid_definition.html.slim
+++ b/app/views/admin/organizations/_organizations_grid_definition.html.slim
@@ -40,6 +40,8 @@
     - g.column name: t('activerecord.attributes.organization.industry'), attribute: 'industry', in_html: false, filter: false
     - g.column name: t('activerecord.attributes.organization.referral_source'), attribute: 'referral_source', in_html: false, filter: false
     - g.column name: t('activerecord.attributes.organization.contact_notes'), attribute: 'contact_notes', in_html: false, filter: false
+    - g.column name: t('activerecord.attributes.organization.inception'), attribute: 'inception_value', in_html: false, filter: false do |organization|
+      - organization.inception_label
     
     - g.column name: t('activerecord.attributes.organization.additional_people'), attribute: 'name',
       assoc: :people, table_alias: 'members', in_html: false, filter: false do |organization|

--- a/config/locales/en/database.en.yml
+++ b/config/locales/en/database.en.yml
@@ -35,6 +35,10 @@ en:
         video: 'Video'
         document: 'Document'
         contract: 'Contract'
+      organization_inception:
+        startup: 'Startup'
+        conversion: 'Conversion'
+        recovered: 'Recovered'
       progress_metric:
         change_plan: 'In need of changing its whole plan'
         change_events: 'In need of changing some events'

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -115,6 +115,7 @@ en:
         tax_no: "Tax ID"
         country: "Country"
         website: "Website"
+        inception: "Inception"
       person:
         birth_date: "Birth Date"
         city: "City"

--- a/db/migrate/20210920172500_add_inception_to_organizations.rb
+++ b/db/migrate/20210920172500_add_inception_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddInceptionToOrganizations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :organizations, :inception_value, :string
+  end
+end

--- a/db/migrate/20210928153001_migrate_and_remove_old_is_recovered_field.rb
+++ b/db/migrate/20210928153001_migrate_and_remove_old_is_recovered_field.rb
@@ -1,0 +1,10 @@
+class MigrateAndRemoveOldIsRecoveredField < ActiveRecord::Migration[6.1]
+  def up
+    execute("UPDATE organizations SET inception_value = 'recovered' WHERE is_recovered = 't'")
+    remove_column(:organizations, :is_recovered)
+  end
+
+  def down
+    add_column(:organizations, :is_recovered, :boolean)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_27_155210) do
+ActiveRecord::Schema.define(version: 2021_09_28_153001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -294,7 +294,6 @@ ActiveRecord::Schema.define(version: 2021_09_27_155210) do
     t.string "fax"
     t.string "inception_value"
     t.string "industry"
-    t.boolean "is_recovered"
     t.string "last_name"
     t.string "legal_name"
     t.string "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -292,6 +292,7 @@ ActiveRecord::Schema.define(version: 2021_09_27_155210) do
     t.integer "division_id"
     t.string "email"
     t.string "fax"
+    t.string "inception_value"
     t.string "industry"
     t.boolean "is_recovered"
     t.string "last_name"

--- a/lib/option_set_creator.rb
+++ b/lib/option_set_creator.rb
@@ -13,6 +13,7 @@ class OptionSetCreator
     create_progress_metric
     create_media_kind
     create_loan_transaction_type
+    create_organization_inception
   end
 
   def create_loan_status
@@ -326,5 +327,31 @@ class OptionSetCreator
       es: I18n.t('database.option_sets.loan_transaction_type.other', locale: 'es')
     }
     other.save
+  end
+
+  def create_organization_inception
+    organization_inception = OptionSet.find_or_create_by(division: Division.root,
+      model_type: Organization.name, model_attribute: 'inception')
+
+    startup = organization_inception.options.find_or_create_by(value: 'startup', position: 1)
+    startup.label_translations = {
+      en: I18n.t('database.option_sets.organization_inception.startup', locale: 'en'),
+      es: I18n.t('database.option_sets.organization_inception.startup', locale: 'es')
+    }
+    startup.save
+
+    conversion = organization_inception.options.find_or_create_by(value: 'conversion', position: 2)
+    conversion.label_translations = {
+      en: I18n.t('database.option_sets.organization_inception.conversion', locale: 'en'),
+      es: I18n.t('database.option_sets.organization_inception.conversion', locale: 'es')
+    }
+    conversion.save
+
+    recovered = organization_inception.options.find_or_create_by(value: 'recovered', position: 3)
+    recovered.label_translations = {
+      en: I18n.t('database.option_sets.organization_inception.recovered', locale: 'en'),
+      es: I18n.t('database.option_sets.organization_inception.recovered', locale: 'es')
+    }
+    recovered.save
   end
 end

--- a/spec/system/admin/organization_flow_spec.rb
+++ b/spec/system/admin/organization_flow_spec.rb
@@ -28,13 +28,30 @@ describe 'organization flow', js: true do
     visit("/")
     select_division(division)
 
-    option_set = Loan.public_level_option_set
-    option_set.options.create(value: 'public', label_translations: { en: 'Public' })
+    OptionSetCreator.new.create_public_level
+    OptionSetCreator.new.create_organization_inception
   end
 
   include_examples "flow" do
     subject { org1 }
     let(:edit_button_name) { 'Edit Co-op' }
+  end
+
+  scenario 'coop creation' do
+    visit new_admin_organization_path
+    fill_in 'organization_name', with: 'Jayita'
+    fill_in 'organization_postal_code', with: '47905' # req'd for country
+    fill_in 'organization_state', with: 'IN'
+    select country.name
+    select 'Conversion', from: 'organization_inception_value'
+
+    click_on 'Create Co-op'
+
+    expect(page).to have_content('Jayita')
+    expect(page).to have_content('Record was successfully created')
+    expect(page).to have_current_path(admin_organization_path(Organization.last))
+    expect(page).to have_content('United States')
+    expect(page).to have_content('Conversion')
   end
 
   scenario 'saving loan redirects to coop page' do
@@ -70,20 +87,5 @@ describe 'organization flow', js: true do
     # when the organization with the note is visited
     visit admin_organization_path(org1)
     expect(page).to have_content(org1.name)
-  end
-
-  scenario 'new coops come with countries' do
-    visit new_admin_organization_path
-    fill_in 'organization_name', with: 'Jayita'
-    fill_in 'organization_postal_code', with: '47905' # req'd for country
-    fill_in 'organization_state', with: 'IN'
-    select country.name
-
-    click_on 'Create Co-op'
-
-    expect(page).to have_content('Jayita')
-    expect(page).to have_content('Record was successfully created')
-    expect(page).to have_current_path(admin_organization_path(Organization.last))
-    expect(page).to have_content('United States')
   end
 end


### PR DESCRIPTION
New field to track how the organization was formed. Replaces the old `is_recovered` flag (which was never used) with something slightly more general and usable.