### PR TITLE
Allow br tag in questionnaire show view

### DIFF
--- a/app/views/admin/loans/questionnaires/_answer.html.slim
+++ b/app/views/admin/loans/questionnaires/_answer.html.slim
@@ -42,7 +42,7 @@
   / Display response as rich text.
 
   / Specify which html tags are allowed.
-  - tags = %w(table tbody tr td b i u ol ul li p img a iframe)
+  - tags = %w(table tbody tr td b i u ol ul li p br img a iframe)
 
   / Specify which attributes are allowed.
   - attrs = %w(class style src data-filename _moz_resizing href target frameborder width height)


### PR DESCRIPTION
Very small change to allow br tags in the show view to support full text data imported from old system. Also to support when user presses <Shift+Enter> in rich text editor to insert a line break as opposed to a paragraph break. Not sure if this would work properly in current system.