### PR TITLE
11993 zero interest txn match txn fix

### DIFF
--- a/app/models/accounting/interest_calculator.rb
+++ b/app/models/accounting/interest_calculator.rb
@@ -201,7 +201,7 @@ module Accounting
       )
       line_item_for(txn, int_rcv_acct).assign_attributes(
         qb_line_id: 2,
-        posting_type: "Credit",
+        posting_type: int_part == 0 ? "Debit" : "Credit",
         amount: int_part
       )
     end

--- a/app/models/accounting/interest_calculator.rb
+++ b/app/models/accounting/interest_calculator.rb
@@ -196,7 +196,7 @@ module Accounting
       )
       line_item_for(txn, prin_acct).assign_attributes(
         qb_line_id: 1,
-        posting_type: "Credit",
+        posting_type: (txn.amount - int_part) == 0 ? "Debit" : "Credit",
         amount: txn.amount - int_part
       )
       line_item_for(txn, int_rcv_acct).assign_attributes(

--- a/spec/models/accounting/interest_calculator_spec.rb
+++ b/spec/models/accounting/interest_calculator_spec.rb
@@ -438,8 +438,8 @@ describe Accounting::InterestCalculator do
       expect(repayment.line_item_for(int_rcv_acct).posting_type).to eq "Debit"
       expect(repayment.line_item_for(prin_acct).amount).to equal_money 100
       expect(repayment.line_item_for(prin_acct).posting_type).to eq "Credit"
-      expect(repayment.line_item_for(txn_acct).amount).to equal_money 100
-      expect(repayment.line_item_for(txn_acct).posting_type).to eq "Debit"
+      expect(repayment.line_item_for(repayment.account).amount).to equal_money 100
+      expect(repayment.line_item_for(repayment.account).posting_type).to eq "Debit"
     end
 
     context "with incorrect line items that allocate non-zero amount to interest" do

--- a/spec/models/accounting/interest_calculator_spec.rb
+++ b/spec/models/accounting/interest_calculator_spec.rb
@@ -508,14 +508,7 @@ describe Accounting::InterestCalculator do
 
     it "the repayment principal account line item is debit as it is in qb " do
       recalculate_and_reload
-      expect(loan.reload.transactions.count).to eq 2
-      expect(Accounting::Transaction.interest_type.exists?(txn_date: "2018-01-31")).to be false
-      expect(disbursement.reload.interest_balance).to equal_money 0
-      expect(disbursement.reload.principal_balance).to equal_money 1000
       updated_repayment = repayment.reload
-      expect(updated_repayment.interest_balance).to equal_money 0
-      expect(updated_repayment.principal_balance).to equal_money 900
-      expect(updated_repayment.principal_balance).to equal_money 900
       expect(updated_repayment.line_item_for(prin_acct).posting_type).to eq "Debit"
       expect(updated_repayment.line_item_for(prin_acct).amount).to eq 0.00
     end

--- a/spec/models/accounting/interest_calculator_spec.rb
+++ b/spec/models/accounting/interest_calculator_spec.rb
@@ -511,6 +511,10 @@ describe Accounting::InterestCalculator do
       recalculate_and_reload
       expect(repayment.line_item_for(prin_acct).posting_type).to eq "Debit"
       expect(repayment.line_item_for(prin_acct).amount).to eq 0.00
+      expect(repayment.line_item_for(int_rcv_acct).posting_type).to eq "Credit"
+      expect(repayment.line_item_for(int_rcv_acct).amount).to equal_money 5.0
+      expect(repayment.line_item_for(repayment.account).posting_type).to eq "Debit"
+      expect(repayment.line_item_for(repayment.account).amount).to equal_money 5.0
     end
   end
 

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -352,7 +352,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
           {'line_items' =>
             [{'id' => '0',
               'description' => 'Eba',
-              'amount' => '10.99',
+              'amount' => '0.00',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
                 'posting_type' => 'Debit',
@@ -366,6 +366,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
               }},
              {'id' => '1',
               'description' => 'Eba',
+              'amount' => '10.99',
               'amount' => '0.00',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
@@ -380,7 +381,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
               }},
              {'id' => '2',
               'description' => 'Repayment',
-              'amount' => '10.99',
+              'amount' => '1.31',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
                 'posting_type' => 'Debit',
@@ -480,7 +481,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
           {'line_items' =>
             [{'id' => '0',
               'description' => 'Eba',
-              'amount' => '10.99',
+              'amount' => '0.0',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
                 'posting_type' => 'Debit',

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -347,7 +347,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
         end
       end
 
-      describe 'repayment with zero debit to principal' do
+      describe 'repayment with zero debit to principal, where whole repayment goes to interest' do
         let(:quickbooks_data) do
           {'line_items' =>
             [{'id' => '0',
@@ -367,10 +367,9 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
              {'id' => '1',
               'description' => 'Eba',
               'amount' => '10.99',
-              'amount' => '0.00',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
-                'posting_type' => 'Debit',
+                'posting_type' => 'Credit',
                 'entity' => {
                   'type' => 'Customer',
                   'entity_ref' => {'value' => customer.qb_id, 'name' => customer.name, 'type' => nil}
@@ -381,7 +380,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
               }},
              {'id' => '2',
               'description' => 'Repayment',
-              'amount' => '1.31',
+              'amount' => '10.99',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
                 'posting_type' => 'Debit',
@@ -400,7 +399,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
              'last_updated_time' => '2017-04-18T10:14:30.000-07:00'
            },
            'txn_date' => '2017-04-18',
-           'total' => '12.30',
+           'total' => '10.99',
            'doc_number' => 'MS-Managed',
            'private_note' => 'Random stuff'}
         end
@@ -412,7 +411,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
         end
       end
 
-      describe 'repayment with zero debit to interest receivable' do
+      describe 'repayment with zero debit to interest receivable, as in a zero-interest loan' do
         let(:quickbooks_data) do
           {'line_items' =>
             [{'id' => '0',
@@ -445,7 +444,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
               }},
              {'id' => '2',
               'description' => 'Repayment',
-              'amount' => '1.31',
+              'amount' => '10.99',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
                 'posting_type' => 'Debit',
@@ -464,7 +463,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
              'last_updated_time' => '2017-04-18T10:14:30.000-07:00'
            },
            'txn_date' => '2017-04-18',
-           'total' => '12.30',
+           'total' => '10.99',
            'doc_number' => 'MS-Managed',
            'private_note' => 'Random stuff'}
         end

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -352,7 +352,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
           {'line_items' =>
             [{'id' => '0',
               'description' => 'Eba',
-              'amount' => '0.0',
+              'amount' => '10.99',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
                 'posting_type' => 'Debit',
@@ -366,10 +366,10 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
               }},
              {'id' => '1',
               'description' => 'Eba',
-              'amount' => '10.99',
+              'amount' => '0.00',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
-                'posting_type' => 'Credit',
+                'posting_type' => 'Debit',
                 'entity' => {
                   'type' => 'Customer',
                   'entity_ref' => {'value' => customer.qb_id, 'name' => customer.name, 'type' => nil}
@@ -380,7 +380,7 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
               }},
              {'id' => '2',
               'description' => 'Repayment',
-              'amount' => '1.31',
+              'amount' => '10.99',
               'detail_type' => 'JournalEntryLineDetail',
               'journal_entry_line_detail' => {
                 'posting_type' => 'Debit',


### PR DESCRIPTION
See https://docs.google.com/document/d/1oy7WHpMWaqdrsHu3JDJ1lC8DGp4HEI2GcSqjxlJERBk/edit for context. 

QB API turns any 0.00 line item's posting type to Debit even if we send Credit. This was causing problems with matched txns because Madeline was trying to change the posting type on matched txns which is understandably not allowed.  This PR changes interest calculator, which handles making/editing line items we send to qb, set posting type to debit when amt is zero. The journal entry extractor was already set up tohandle a zero debit on interest when setting the repayment type on the txn's return trip from qb to madeline.