### PR TITLE
12000 per division data exports

### DIFF
--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -43,8 +43,13 @@ class EnhancedLoanDataExport < StandardLoanDataExport
     row + questions.map(&:id)
   end
 
+  # Returns questions in the order we want them to show up in the header row.
   def questions
-    @questions ||= Question.where(data_type: Q_DATA_TYPES).sort_by(&:label)
+    @questions ||= QuestionSet.order(:kind).flat_map do |question_set|
+      question_set.root_group.self_and_descendants_preordered.select do |q|
+        Q_DATA_TYPES.include?(q.data_type)
+      end
+    end
   end
 
   def questions_by_id

--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -17,15 +17,24 @@ class EnhancedLoanDataExport < StandardLoanDataExport
         if question.present?
           response = Response.new(loan: loan, question: question,
                                   response_set: response_set, data: response_data)
-          if response.has_rating?
-            result[q_id.to_i] = response.rating
-          elsif response.has_number?
-            result[q_id.to_i] = response.number
-          elsif response.has_boolean?
-            result[q_id.to_i] = response.boolean
-          elsif response.has_text?
-            result[q_id.to_i] = response.text
-          end
+
+          # Note, this approach will exclude parts of compound data types, such as `range`,
+          # which can have both a `rating` and a `text` component.
+          # `url`, `start_cell`, and `end_cell` components from questions with `has_embeddable_media`=true
+          # are also not included, nor are `business_canvas`, and `breakeven`, which would be way too big
+          # to put in a CSV cell.
+          result[q_id.to_i] =
+            if response.not_applicable?
+              "N/A"
+            elsif response.has_rating?
+              response.rating
+            elsif response.has_number?
+              response.number
+            elsif response.has_boolean?
+              response.boolean
+            elsif response.has_text?
+              response.text
+            end
         end
       end
     end

--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -1,5 +1,5 @@
 class EnhancedLoanDataExport < StandardLoanDataExport
-  Q_DATA_TYPES = ["number", "percentage", "rating", "currency"]
+  Q_DATA_TYPES = ["boolean", "text", "number", "percentage", "rating", "currency"]
 
   private
 
@@ -21,6 +21,10 @@ class EnhancedLoanDataExport < StandardLoanDataExport
             result[q_id.to_i] = response.rating
           elsif response.has_number?
             result[q_id.to_i] = response.number
+          elsif response.has_boolean?
+            result[q_id.to_i] = response.boolean
+          elsif response.has_text?
+            result[q_id.to_i] = response.text
           end
         end
       end

--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -3,7 +3,7 @@ class EnhancedLoanDataExport < StandardLoanDataExport
 
   private
 
-  def loan_data_as_hash(loan)
+  def object_data_as_hash(loan)
     super.merge(response_hash(loan))
   end
 
@@ -63,12 +63,8 @@ class EnhancedLoanDataExport < StandardLoanDataExport
     @questions_by_id ||= questions.index_by(&:id)
   end
 
-  # Methods below decouple order in BASE_HEADERS constant and question map from the order in which values are added to data row
-  def headers_key
-    @headers_key ||= StandardLoanDataExport::HEADERS + questions.map(&:id)
-  end
-
-  def insert_in_row(column_name, row_array, value)
-    row_array[headers_key.index(column_name)] = value
+  # Returns the list of symbols representing headers in the order they should appear.
+  def header_symbols
+    @header_symbols ||= StandardLoanDataExport::HEADERS + questions.map(&:id)
   end
 end

--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -45,7 +45,7 @@ class EnhancedLoanDataExport < StandardLoanDataExport
 
   # Returns questions in the order we want them to show up in the header row.
   def questions
-    @questions ||= QuestionSet.order(:kind).flat_map do |question_set|
+    @questions ||= QuestionSet.where(division: division_id).order(:kind).flat_map do |question_set|
       question_set.root_group.self_and_descendants_preordered.select do |q|
         Q_DATA_TYPES.include?(q.data_type)
       end

--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -7,31 +7,25 @@ class EnhancedLoanDataExport < StandardLoanDataExport
     super.merge(response_hash(loan))
   end
 
+  # We index questions by ID in this hash but use question labels in the header row.
   def response_hash(loan)
     result = {}
     response_sets = ResponseSet.joins(:question_set).where(loan: loan).order("question_sets.kind")
-
     response_sets.each do |response_set|
       response_set.custom_data.each do |q_id, response_data|
-        question = memoized_questions[q_id.to_i]
+        question = questions_by_id[q_id.to_i]
         if question.present?
           response = Response.new(loan: loan, question: question,
                                   response_set: response_set, data: response_data)
           if response.has_rating?
-            result[q_id] = response.rating
+            result[q_id.to_i] = response.rating
           elsif response.has_number?
-            result[q_id] = response.number
+            result[q_id.to_i] = response.number
           end
         end
       end
     end
     result
-  end
-
-  def question_id_row
-    row = [I18n.t("standard_loan_data_exports.headers.question_id")]
-    row[StandardLoanDataExport::HEADERS.size - 1] = nil
-    row + questions_map.keys.sort
   end
 
   def header_rows
@@ -40,30 +34,29 @@ class EnhancedLoanDataExport < StandardLoanDataExport
 
   def main_header_row
     headers = StandardLoanDataExport::HEADERS.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
-    headers + questions_map.keys.sort.map { |k| questions_map[k] }
+    headers + questions.map { |q| q.label.to_s }
   end
 
-  def questions_map
-    @questions_map ||= make_questions_label_map
+  def question_id_row
+    row = [I18n.t("standard_loan_data_exports.headers.question_id")]
+    row[StandardLoanDataExport::HEADERS.size - 1] = nil
+    row + questions.map(&:id)
   end
 
-  # map q_ids as strings (so that they can be treated same as base headers in #insert_in_row) to labels
-  def make_questions_label_map
-    q_id_to_label_map = {}
-    Question.where(data_type: Q_DATA_TYPES).find_each { |q| q_id_to_label_map[q.id.to_s] = q.label.to_s }
-    q_id_to_label_map
+  def questions
+    @questions ||= Question.where(data_type: Q_DATA_TYPES).sort_by(&:label)
   end
 
-  def memoized_questions
-    @memoized_questions ||= Question.where(data_type: Q_DATA_TYPES).index_by(&:id)
+  def questions_by_id
+    @questions_by_id ||= questions.index_by(&:id)
   end
 
   # Methods below decouple order in BASE_HEADERS constant and question map from the order in which values are added to data row
   def headers_key
-    @headers_key = @headers_key || StandardLoanDataExport::HEADERS + questions_map.keys.sort
+    @headers_key ||= StandardLoanDataExport::HEADERS + questions.map(&:id)
   end
 
   def insert_in_row(column_name, row_array, value)
-    row_array[headers_key.index(column_name.to_s)] = value
+    row_array[headers_key.index(column_name)] = value
   end
 end

--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -1,5 +1,5 @@
 class EnhancedLoanDataExport < StandardLoanDataExport
-  Q_DATA_TYPES = ['number', 'percentage', 'rating', 'currency']
+  Q_DATA_TYPES = ["number", "percentage", "rating", "currency"]
 
   private
 
@@ -9,17 +9,19 @@ class EnhancedLoanDataExport < StandardLoanDataExport
 
   def response_hash(loan)
     result = {}
-    response_set = ResponseSet.find_by(loan_id: loan.id)
-    return result if response_set.nil?
+    response_sets = ResponseSet.joins(:question_set).where(loan: loan).order("question_sets.kind")
 
-    response_set.custom_data.each do |q_id, response_data|
-      question = memoized_questions[q_id.to_i]
-      if question.present?
-        response = Response.new(loan: loan, question: question, response_set: response_set, data: response_data)
-        if response.has_rating?
-          result[q_id] = response.rating
-        elsif response.has_number?
-          result[q_id] = response.number
+    response_sets.each do |response_set|
+      response_set.custom_data.each do |q_id, response_data|
+        question = memoized_questions[q_id.to_i]
+        if question.present?
+          response = Response.new(loan: loan, question: question,
+                                  response_set: response_set, data: response_data)
+          if response.has_rating?
+            result[q_id] = response.rating
+          elsif response.has_number?
+            result[q_id] = response.number
+          end
         end
       end
     end

--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -1,107 +1,17 @@
-class EnhancedLoanDataExport < DataExport
+class EnhancedLoanDataExport < StandardLoanDataExport
   Q_DATA_TYPES = ['number', 'percentage', 'rating', 'currency']
-  BASE_HEADERS = [
-    'loan_id',
-    'name',
-    'division',
-    'cooperative',
-    'country',
-    'address',
-    'city',
-    'state',
-    'postal_code',
-    'status',
-    'actual_end_date',
-    'actual_first_payment_date',
-    'actual_first_interest_payment_date',
-    'actual_return',
-    'projected_end_date',
-    'projected_first_payment_date',
-    'projected_first_interest_payment_date',
-    'projected_return',
-    'signing_date',
-    'length_months',
-    'loan_type',
-    'currency',
-    'amount',
-    'rate',
-    'final_repayment_formula',
-    'primary_agent',
-    'secondary_agent',
-    'num_accounting_warnings',
-    'num_accounting_errors',
-    'sum_of_disbursements',
-    'sum_of_repayments',
-    'change_in_principal',
-    'change_in_interest'
-  ]
-
-  # Subclass exists only to implement process_data. No additional public methods should be added to this subclass.
-  def process_data
-    @child_errors = []
-    data = []
-    data << header_row
-    data << question_id_row
-    Loan.find_each do |loan|
-      begin
-        data << hash_to_row(loan_data_as_hash(loan))
-      rescue => e
-        @child_errors << {loan_id: loan.id, message: e.message}
-        next
-      end
-    end
-    self.update(data: data)
-
-    unless @child_errors.empty?
-      raise DataExportError.new(message: "Data export had child errors.", child_errors: @child_errors)
-    end
-  end
 
   private
 
   def loan_data_as_hash(loan)
-    result = {
-      loan_id: loan.id,
-      name: loan.name,
-      division: loan.division_name,
-      cooperative: loan.coop_name,
-      address: loan.coop_street_address,
-      city: loan.coop_city,
-      state: loan.coop_state,
-      country: loan.coop_country&.name,
-      postal_code: loan.coop_postal_code,
-      status: loan.status.to_s,
-      actual_end_date: loan.actual_end_date,
-      actual_first_payment_date: loan.actual_first_payment_date,
-      actual_first_interest_payment_date: loan.actual_first_interest_payment_date,
-      actual_return: loan.actual_return,
-      projected_end_date: loan.projected_end_date,
-      projected_first_payment_date: loan.projected_first_payment_date,
-      projected_first_interest_payment_date: loan.projected_first_interest_payment_date,
-      projected_return: loan.projected_return,
-      signing_date: loan.signing_date,
-      length_months: loan.length_months,
-      loan_type: loan.type,
-      currency: loan.currency&.name,
-      amount: loan.amount,
-      rate: loan.rate,
-      final_repayment_formula: loan.final_repayment_formula,
-      primary_agent: loan.primary_agent&.name,
-      secondary_agent: loan.secondary_agent&.name,
-      num_accounting_warnings: loan.num_sync_issues_by_level(:warning),
-      num_accounting_errors: loan.num_sync_issues_by_level(:error),
-      sum_of_disbursements: loan.sum_of_disbursements(start_date: start_date, end_date: end_date),
-      sum_of_repayments: loan.sum_of_repayments(start_date: start_date, end_date: end_date),
-      change_in_principal: loan.change_in_principal(start_date: start_date, end_date: end_date),
-      change_in_interest: loan.change_in_interest(start_date: start_date, end_date: end_date)
-    }
-    result.merge(response_hash(loan))
+    super.merge(response_hash(loan))
   end
 
   def response_hash(loan)
     result = {}
     response_set = ResponseSet.find_by(loan_id: loan.id)
     return result if response_set.nil?
+
     response_set.custom_data.each do |q_id, response_data|
       question = memoized_questions[q_id.to_i]
       if question.present?
@@ -118,18 +28,16 @@ class EnhancedLoanDataExport < DataExport
 
   def question_id_row
     row = [I18n.t("standard_loan_data_exports.headers.question_id")]
-    row[BASE_HEADERS.size - 1] = nil
+    row[StandardLoanDataExport::HEADERS.size - 1] = nil
     row + questions_map.keys.sort
   end
 
-  def header_row
-    @header_row ||= make_header_row
+  def header_rows
+    [main_header_row, question_id_row]
   end
 
-  def make_header_row
-    headers = BASE_HEADERS.map do |h|
-      I18n.t("standard_loan_data_exports.headers.#{h}")
-    end
+  def main_header_row
+    headers = StandardLoanDataExport::HEADERS.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
     headers + questions_map.keys.sort.map { |k| questions_map[k] }
   end
 
@@ -150,13 +58,7 @@ class EnhancedLoanDataExport < DataExport
 
   # Methods below decouple order in BASE_HEADERS constant and question map from the order in which values are added to data row
   def headers_key
-    @headers_key = @headers_key || BASE_HEADERS + questions_map.keys.sort
-  end
-
-  def hash_to_row(hash)
-    data_row = []
-    hash.each { |k, v| insert_in_row(k, data_row, v) }
-    data_row
+    @headers_key = @headers_key || StandardLoanDataExport::HEADERS + questions_map.keys.sort
   end
 
   def insert_in_row(column_name, row_array, value)

--- a/app/models/enhanced_loan_data_export.rb
+++ b/app/models/enhanced_loan_data_export.rb
@@ -80,7 +80,7 @@ class EnhancedLoanDataExport < DataExport
       projected_first_interest_payment_date: loan.projected_first_interest_payment_date,
       projected_return: loan.projected_return,
       signing_date: loan.signing_date,
-      length_months: loan.length_months, 
+      length_months: loan.length_months,
       loan_type: loan.type,
       currency: loan.currency&.name,
       amount: loan.amount,

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -112,14 +112,7 @@ class Question < ApplicationRecord
     else
       result = [data_type.to_sym]
     end
-
-    if has_embeddable_media
-      if result
-        result << :url
-      else
-        raise "has_embeddable_media flag enabled for unexpected data_type: #{data_type}"
-      end
-    end
+    result << :url
     result
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -100,22 +100,6 @@ class Question < ApplicationRecord
     false
   end
 
-  # Responses are made up of one or more value types. e.g. a `range` is composed of a `rating` and a `text`
-  # This method returns which value type should be included with a this question's responses.
-  def value_types
-    if data_type == "range"
-      result = [:rating, :text]
-    elsif data_type == "percentage"
-      result = [:number, :percentage]
-    elsif data_type == "currency"
-      result = [:number, :currency]
-    else
-      result = [data_type.to_sym]
-    end
-    result.concat([:url, :start_cell, :end_cell])
-    result
-  end
-
   # for now use a stringified primary key
   # todo: consider using the internal name when available - needs further discussion
   def json_key

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -100,14 +100,14 @@ class Question < ApplicationRecord
     false
   end
 
-  # List of value keys for fields which have nested values
+  # Responses are made up of one or more component keys. e.g. a `range` is composed of a `rating` and a `text`
+  # This method returns which keys should be included with a this question's responses.
   def value_types
-    # raise "invalid data_type" unless DATA_TYPES.include?(data_type.to_sym)
-    if data_type == 'range'
+    if data_type == "range"
       result = [:rating, :text]
-    elsif data_type == 'percentage'
+    elsif data_type == "percentage"
       result = [:number, :percentage]
-    elsif data_type == 'currency'
+    elsif data_type == "currency"
       result = [:number, :currency]
     else
       result = [data_type.to_sym]

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -100,8 +100,8 @@ class Question < ApplicationRecord
     false
   end
 
-  # Responses are made up of one or more component keys. e.g. a `range` is composed of a `rating` and a `text`
-  # This method returns which keys should be included with a this question's responses.
+  # Responses are made up of one or more value types. e.g. a `range` is composed of a `rating` and a `text`
+  # This method returns which value type should be included with a this question's responses.
   def value_types
     if data_type == "range"
       result = [:rating, :text]
@@ -112,7 +112,7 @@ class Question < ApplicationRecord
     else
       result = [data_type.to_sym]
     end
-    result << :url
+    result.concat([:url, :start_cell, :end_cell])
     result
   end
 

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -2,19 +2,19 @@
 class Response
   include ProgressCalculable
 
-  attr_accessor :loan, :question, :response_set, :text, :string, :number, :boolean,
+  attr_accessor :loan, :question, :response_set, :text, :number, :boolean,
     :rating, :url, :start_cell, :end_cell, :owner, :breakeven, :business_canvas, :not_applicable
 
   delegate :group?, :active?, :required?, to: :question
 
-  TYPES = %i(boolean breakeven business_canvas currency number percentage rating string text url)
+  TYPES = %i(boolean breakeven business_canvas currency number percentage rating text url)
 
   def initialize(loan:, question:, response_set:, data:)
     data = (data || {}).with_indifferent_access
     @loan = loan
     @question = question
     @response_set = response_set
-    %w(boolean business_canvas end_cell number rating start_cell not_applicable string text url).each do |i|
+    %w(boolean business_canvas end_cell number rating start_cell not_applicable text url).each do |i|
       instance_variable_set("@#{i}", data[i.to_sym])
     end
     @breakeven = remove_blanks(data[:breakeven])
@@ -59,7 +59,7 @@ class Response
     if group?
       children.all?(&:blank?) || children.all?(&:not_applicable?)
     else
-      !not_applicable? && text.blank? && string.blank? && number.blank? && rating.blank? &&
+      !not_applicable? && text.blank? && number.blank? && rating.blank? &&
         boolean.blank? && url.blank? && breakeven_report.blank? && business_canvas_blank?
     end
   end

--- a/app/models/standard_loan_data_export.rb
+++ b/app/models/standard_loan_data_export.rb
@@ -35,29 +35,15 @@ class StandardLoanDataExport < DataExport
     :change_in_interest
   ]
 
-  # Subclass exists only to implement process_data. No additional public methods should be added to this subclass.
-  def process_data
-    @child_errors = []
-    data = []
-    data.concat(header_rows)
-    Loan.find_each do |l|
-      begin
-        data << hash_to_row(loan_data_as_hash(l))
-      rescue => e
-        @child_errors << {loan_id: l.id, message: e.message}
-        next
-      end
-    end
-    self.update(data: data)
+  protected
 
-    unless @child_errors.empty?
-      raise DataExportError.new(message: "Data export had child errors.", child_errors: @child_errors)
-    end
+  def scope
+    Loan
   end
 
   private
 
-  def loan_data_as_hash(loan)
+  def object_data_as_hash(loan)
     {
       loan_id: loan.id,
       name: loan.name,
@@ -95,15 +81,9 @@ class StandardLoanDataExport < DataExport
     }
   end
 
-  # decouples order in HEADERS constant from order values are added to data row
-  def hash_to_row(hash)
-    data_row = []
-    hash.each { |k, v| insert_in_row(k, data_row, v) }
-    data_row
-  end
-
-  def insert_in_row(column_name, row_array, value)
-    row_array[HEADERS.index(column_name)] = value
+  # Returns the list of symbols representing headers in the order they should appear.
+  def header_symbols
+    HEADERS
   end
 
   def header_rows

--- a/app/models/standard_loan_data_export.rb
+++ b/app/models/standard_loan_data_export.rb
@@ -1,45 +1,45 @@
 class StandardLoanDataExport < DataExport
   HEADERS = [
-    'loan_id',
-    'name',
-    'division',
-    'cooperative',
-    'country',
-    'address',
-    'city',
-    'state',
-    'postal_code',
-    'status',
-    'actual_end_date',
-    'actual_first_payment_date',
-    'actual_first_interest_payment_date',
-    'actual_return',
-    'projected_end_date',
-    'projected_first_payment_date',
-    'projected_first_interest_payment_date',
-    'projected_return',
-    'signing_date',
-    'length_months',
-    'loan_type',
-    'currency',
-    'amount',
-    'rate',
-    'final_repayment_formula',
-    'primary_agent',
-    'secondary_agent',
-    'num_accounting_warnings',
-    'num_accounting_errors',
-    'sum_of_disbursements',
-    'sum_of_repayments',
-    'change_in_principal',
-    'change_in_interest'
+    "loan_id",
+    "name",
+    "division",
+    "cooperative",
+    "country",
+    "address",
+    "city",
+    "state",
+    "postal_code",
+    "status",
+    "actual_end_date",
+    "actual_first_payment_date",
+    "actual_first_interest_payment_date",
+    "actual_return",
+    "projected_end_date",
+    "projected_first_payment_date",
+    "projected_first_interest_payment_date",
+    "projected_return",
+    "signing_date",
+    "length_months",
+    "loan_type",
+    "currency",
+    "amount",
+    "rate",
+    "final_repayment_formula",
+    "primary_agent",
+    "secondary_agent",
+    "num_accounting_warnings",
+    "num_accounting_errors",
+    "sum_of_disbursements",
+    "sum_of_repayments",
+    "change_in_principal",
+    "change_in_interest"
   ]
 
   # Subclass exists only to implement process_data. No additional public methods should be added to this subclass.
   def process_data
     @child_errors = []
     data = []
-    data << header_row
+    data.concat(header_rows)
     Loan.find_each do |l|
       begin
         data << hash_to_row(loan_data_as_hash(l))
@@ -97,7 +97,7 @@ class StandardLoanDataExport < DataExport
 
   # decouples order in HEADERS constant from order values are added to data row
   def hash_to_row(hash)
-    data_row = Array(HEADERS.size)
+    data_row = []
     hash.each { |k, v| insert_in_row(k, data_row, v) }
     data_row
   end
@@ -106,9 +106,7 @@ class StandardLoanDataExport < DataExport
     row_array[HEADERS.index(column_name.to_s)] = value
   end
 
-  def header_row
-    HEADERS.map do |h|
-      I18n.t("standard_loan_data_exports.headers.#{h}")
-    end
+  def header_rows
+    [HEADERS.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }]
   end
 end

--- a/app/models/standard_loan_data_export.rb
+++ b/app/models/standard_loan_data_export.rb
@@ -1,38 +1,38 @@
 class StandardLoanDataExport < DataExport
   HEADERS = [
-    "loan_id",
-    "name",
-    "division",
-    "cooperative",
-    "country",
-    "address",
-    "city",
-    "state",
-    "postal_code",
-    "status",
-    "actual_end_date",
-    "actual_first_payment_date",
-    "actual_first_interest_payment_date",
-    "actual_return",
-    "projected_end_date",
-    "projected_first_payment_date",
-    "projected_first_interest_payment_date",
-    "projected_return",
-    "signing_date",
-    "length_months",
-    "loan_type",
-    "currency",
-    "amount",
-    "rate",
-    "final_repayment_formula",
-    "primary_agent",
-    "secondary_agent",
-    "num_accounting_warnings",
-    "num_accounting_errors",
-    "sum_of_disbursements",
-    "sum_of_repayments",
-    "change_in_principal",
-    "change_in_interest"
+    :loan_id,
+    :name,
+    :division,
+    :cooperative,
+    :country,
+    :address,
+    :city,
+    :state,
+    :postal_code,
+    :status,
+    :actual_end_date,
+    :actual_first_payment_date,
+    :actual_first_interest_payment_date,
+    :actual_return,
+    :projected_end_date,
+    :projected_first_payment_date,
+    :projected_first_interest_payment_date,
+    :projected_return,
+    :signing_date,
+    :length_months,
+    :loan_type,
+    :currency,
+    :amount,
+    :rate,
+    :final_repayment_formula,
+    :primary_agent,
+    :secondary_agent,
+    :num_accounting_warnings,
+    :num_accounting_errors,
+    :sum_of_disbursements,
+    :sum_of_repayments,
+    :change_in_principal,
+    :change_in_interest
   ]
 
   # Subclass exists only to implement process_data. No additional public methods should be added to this subclass.
@@ -103,7 +103,7 @@ class StandardLoanDataExport < DataExport
   end
 
   def insert_in_row(column_name, row_array, value)
-    row_array[HEADERS.index(column_name.to_s)] = value
+    row_array[HEADERS.index(column_name)] = value
   end
 
   def header_rows

--- a/app/models/standard_loan_data_export.rb
+++ b/app/models/standard_loan_data_export.rb
@@ -38,7 +38,7 @@ class StandardLoanDataExport < DataExport
   protected
 
   def scope
-    Loan
+    Loan.where(division_id: division.self_and_descendants.pluck(:id))
   end
 
   private

--- a/spec/factories/data_exports_factory.rb
+++ b/spec/factories/data_exports_factory.rb
@@ -7,9 +7,13 @@ FactoryBot.define do
     locale_code { "en" }
     data { nil }
     type { DataExport }
-  end
 
-  factory :standard_loan_data_export, parent: :data_export, class: 'StandardLoanDataExport' do
-    type { StandardLoanDataExport }
+    factory :standard_loan_data_export, class: 'StandardLoanDataExport' do
+      type { StandardLoanDataExport }
+    end
+
+    factory :enhanced_loan_data_export, class: 'EnhancedLoanDataExport' do
+      type { EnhancedLoanDataExport }
+    end
   end
 end

--- a/spec/factories/questions_factory.rb
+++ b/spec/factories/questions_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :question do
+    transient do
+      label { Faker::Lorem.words(2).join(' ') }
+    end
+
     division { root_division }
     question_set
     internal_name { Faker::Lorem.words(2).join('_').downcase }
@@ -10,8 +14,12 @@ FactoryBot.define do
       model.parent ||= model.question_set.root_group
     end
 
-    after(:create) do |model|
-      model.set_label(Faker::Lorem.words(2).join(' '))
+    after(:create) do |model, evaluator|
+      model.update!(label_en: evaluator.label)
+    end
+
+    trait :with_url do
+      has_embeddable_media { true }
     end
   end
 end

--- a/spec/models/enhanced_loan_data_export_spec.rb
+++ b/spec/models/enhanced_loan_data_export_spec.rb
@@ -63,11 +63,11 @@ describe EnhancedLoanDataExport, type: :model do
 
       it "should create correct data attr" do
         export.process_data
-        expect(export.data[0]).to eq(base_headers + ["QC2", "QC4"])
-        expect(export.data[1]).to eq(["Question ID"] + id_row_nils + [qc2, qc4].map(&:id))
+        expect(export.data[0]).to eq(base_headers + ["QC1", "QC2", "QC3", "QC4"])
+        expect(export.data[1]).to eq(["Question ID"] + id_row_nils + [qc1, qc2, qc3, qc4].map(&:id))
 
-        row1 = ["10"]
-        row2 = ["20", "4"]
+        row1 = ["yes", "10", "foo\nbar"]
+        row2 = ["", "20", "lorp", "4"]
         row3 = []
         expect(response_data).to contain_exactly(row1, row2, row3)
       end
@@ -95,12 +95,12 @@ describe EnhancedLoanDataExport, type: :model do
 
         it "should create correct data attr" do
           export.process_data
-          expect(export.data[0]).to eq(base_headers + ["QC2", "QC4", "QP1"])
-          expect(export.data[1]).to eq(["Question ID"] + id_row_nils + [qc2, qc4, qp1].map(&:id))
+          expect(export.data[0]).to eq(base_headers + ["QC1", "QC2", "QC3", "QC4", "QP1"])
+          expect(export.data[1]).to eq(["Question ID"] + id_row_nils + [qc1, qc2, qc3, qc4, qp1].map(&:id))
 
-          row1 = ["10", nil, "7"]
-          row2 = ["20", "4"]
-          row3 = [nil, nil, "99.9"]
+          row1 = ["yes", "10", "foo\nbar", nil, "7"]
+          row2 = ["", "20", "lorp", "4"]
+          row3 = [nil, nil, nil, nil, "99.9"]
           expect(response_data).to contain_exactly(row1, row2, row3)
         end
       end

--- a/spec/models/enhanced_loan_data_export_spec.rb
+++ b/spec/models/enhanced_loan_data_export_spec.rb
@@ -67,7 +67,7 @@ describe EnhancedLoanDataExport, type: :model do
         expect(export.data[1]).to eq(["Question ID"] + id_row_nils + [qc1, qc2, qc3, qc4].map(&:id))
 
         row1 = ["yes", "10", "foo\nbar"]
-        row2 = ["", "20", "lorp", "4"]
+        row2 = ["N/A", "20", "lorp", "4"]
         row3 = []
         expect(response_data).to contain_exactly(row1, row2, row3)
       end
@@ -99,7 +99,7 @@ describe EnhancedLoanDataExport, type: :model do
           expect(export.data[1]).to eq(["Question ID"] + id_row_nils + [qc1, qc2, qc3, qc4, qp1].map(&:id))
 
           row1 = ["yes", "10", "foo\nbar", nil, "7"]
-          row2 = ["", "20", "lorp", "4"]
+          row2 = ["N/A", "20", "lorp", "4"]
           row3 = [nil, nil, nil, nil, "99.9"]
           expect(response_data).to contain_exactly(row1, row2, row3)
         end

--- a/spec/models/enhanced_loan_data_export_spec.rb
+++ b/spec/models/enhanced_loan_data_export_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+describe EnhancedLoanDataExport, type: :model do
+  before do
+    OptionSetCreator.new.create_loan_status
+  end
+
+  describe "process_data" do
+    let(:division) { create(:division) }
+    let!(:loan1) { create(:loan, :active, division: division) }
+    let!(:loan2) { create(:loan, :active, division: division) }
+    let!(:criteria) { create(:question_set, kind: "loan_criteria", division: division) }
+    let(:root) { criteria.root_group }
+    let(:qattrs) { {question_set: criteria, division: division} }
+    let!(:q1) { create(:question, qattrs.merge(data_type: "boolean", label: "Q1")) }
+    let!(:q2) { create(:question, qattrs.merge(data_type: "percentage", label: "Q2")) }
+    let!(:q3) { create(:question, qattrs.merge(data_type: "text", label: "Q3")) }
+    let!(:q4) { create(:question, :with_url, qattrs.merge(data_type: "range", label: "Q4")) }
+    let!(:r1) do
+      create(:response_set,
+             question_set: criteria,
+             loan: loan1,
+             custom_data: {
+               q1.id.to_s => {boolean: "yes", not_applicable: "no"},
+               q2.id.to_s => {number: "10", not_applicable: "no"},
+               q3.id.to_s => {text: "foo\nbar", not_applicable: "no"},
+               q4.id.to_s => {rating: "4", text: "baz", url: "https://example.com/1", not_applicable: "no"}
+             })
+    end
+    let!(:r2) do
+      create(:response_set,
+             question_set: criteria,
+             loan: loan2,
+             custom_data: {
+               q1.id.to_s => {boolean: "", not_applicable: "yes"},
+               q2.id.to_s => {number: "20", not_applicable: "no"},
+               q3.id.to_s => {text: "lorp", not_applicable: "no"},
+               q4.id.to_s => {rating: "", text: "", url: "", not_applicable: "yes"}
+             })
+    end
+    let!(:export) { create(:enhanced_loan_data_export, data: nil) }
+
+    it "should create correct data attr" do
+      export.process_data
+      base_headers = described_class::BASE_HEADERS
+      base_headers = base_headers.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
+      expect(export.data[0]).to eq(base_headers + ["Q2"])
+      expect(export.data[1]).to eq(["Question ID"] + ([nil] * (base_headers.size - 1)) + [q2.id.to_s])
+
+      row1 = ["10"]
+      row2 = ["20"]
+      enhanced_data = export.data[2..-1].map { |row| row[base_headers.size..-1] }
+      expect(enhanced_data).to contain_exactly(row1, row2)
+    end
+  end
+end

--- a/spec/models/enhanced_loan_data_export_spec.rb
+++ b/spec/models/enhanced_loan_data_export_spec.rb
@@ -9,33 +9,52 @@ describe EnhancedLoanDataExport, type: :model do
     let(:division) { create(:division) }
     let!(:loan1) { create(:loan, :active, division: division) }
     let!(:loan2) { create(:loan, :active, division: division) }
+    let!(:loan3) { create(:loan, :active, division: division) }
     let!(:criteria) { create(:question_set, kind: "loan_criteria", division: division) }
-    let(:root) { criteria.root_group }
-    let(:qattrs) { {question_set: criteria, division: division} }
-    let!(:q1) { create(:question, qattrs.merge(data_type: "boolean", label: "Q1")) }
-    let!(:q2) { create(:question, qattrs.merge(data_type: "percentage", label: "Q2")) }
-    let!(:q3) { create(:question, qattrs.merge(data_type: "text", label: "Q3")) }
-    let!(:q4) { create(:question, :with_url, qattrs.merge(data_type: "range", label: "Q4")) }
-    let!(:r1) do
+    let!(:post_analysis) { create(:question_set, kind: "loan_post_analysis", division: division) }
+    let(:qcattrs) { {question_set: criteria, division: division} }
+    let!(:qc1) { create(:question, qcattrs.merge(data_type: "boolean", label: "QC1")) }
+    let!(:qc2) { create(:question, qcattrs.merge(data_type: "percentage", label: "QC2")) }
+    let!(:qc4) { create(:question, :with_url, qcattrs.merge(data_type: "rating", label: "QC4")) }
+    let!(:qc3) { create(:question, qcattrs.merge(data_type: "text", label: "QC3")) }
+    let(:qpattrs) { {question_set: post_analysis, division: division} }
+    let!(:qp1) { create(:question, :with_url, qpattrs.merge(data_type: "number", label: "QP1")) }
+    let!(:r1_c) do
       create(:response_set,
              question_set: criteria,
              loan: loan1,
              custom_data: {
-               q1.id.to_s => {boolean: "yes", not_applicable: "no"},
-               q2.id.to_s => {number: "10", not_applicable: "no"},
-               q3.id.to_s => {text: "foo\nbar", not_applicable: "no"},
-               q4.id.to_s => {rating: "4", text: "baz", url: "https://example.com/1", not_applicable: "no"}
+               qc1.id.to_s => {boolean: "yes", not_applicable: "no"},
+               qc2.id.to_s => {number: "10", not_applicable: "no"},
+               qc3.id.to_s => {text: "foo\nbar", not_applicable: "no"},
+               qc4.id.to_s => {rating: "4", url: "https://example.com/1", not_applicable: "no"}
              })
     end
-    let!(:r2) do
+    let!(:r1_p) do
+      create(:response_set,
+             question_set: post_analysis,
+             loan: loan1,
+             custom_data: {
+               qp1.id.to_s => {number: "7", not_applicable: "no"}
+             })
+    end
+    let!(:r2_c) do
       create(:response_set,
              question_set: criteria,
              loan: loan2,
              custom_data: {
-               q1.id.to_s => {boolean: "", not_applicable: "yes"},
-               q2.id.to_s => {number: "20", not_applicable: "no"},
-               q3.id.to_s => {text: "lorp", not_applicable: "no"},
-               q4.id.to_s => {rating: "", text: "", url: "", not_applicable: "yes"}
+               qc1.id.to_s => {boolean: "", not_applicable: "yes"},
+               qc2.id.to_s => {number: "20", not_applicable: "no"},
+               qc3.id.to_s => {text: "lorp", not_applicable: "no"},
+               qc4.id.to_s => {rating: "", url: "", not_applicable: "yes"}
+             })
+    end
+    let!(:r3_p) do
+      create(:response_set,
+             question_set: post_analysis,
+             loan: loan3,
+             custom_data: {
+               qp1.id.to_s => {number: "99.9", not_applicable: "no"}
              })
     end
     let!(:export) { create(:enhanced_loan_data_export, data: nil) }
@@ -44,13 +63,15 @@ describe EnhancedLoanDataExport, type: :model do
       export.process_data
       base_headers = StandardLoanDataExport::HEADERS
       base_headers = base_headers.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
-      expect(export.data[0]).to eq(base_headers + ["Q2"])
-      expect(export.data[1]).to eq(["Question ID"] + ([nil] * (base_headers.size - 1)) + [q2.id.to_s])
+      expect(export.data[0]).to eq(base_headers + ["QC2", "QC4", "QP1"])
+      expect(export.data[1])
+        .to eq(["Question ID"] + ([nil] * (base_headers.size - 1)) + [qc2, qc4, qp1].map(&:id).map(&:to_s))
 
-      row1 = ["10"]
-      row2 = ["20"]
+      row1 = ["10", "4", "7"]
+      row2 = ["20", ""]
+      row3 = [nil, nil, "99.9"]
       enhanced_data = export.data[2..-1].map { |row| row[base_headers.size..-1] }
-      expect(enhanced_data).to contain_exactly(row1, row2)
+      expect(enhanced_data).to contain_exactly(row1, row2, row3)
     end
   end
 end

--- a/spec/models/enhanced_loan_data_export_spec.rb
+++ b/spec/models/enhanced_loan_data_export_spec.rb
@@ -10,12 +10,21 @@ describe EnhancedLoanDataExport, type: :model do
     let!(:loan1) { create(:loan, :active, division: division) }
     let!(:loan2) { create(:loan, :active, division: division) }
     let!(:loan3) { create(:loan, :active, division: division) }
+
     let(:base_headers) do
       StandardLoanDataExport::HEADERS.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
     end
     let(:id_row_nils) { [nil] * (base_headers.size - 1) }
     let(:response_data) { export.data[2..-1].map { |row| row[base_headers.size..-1] } }
-    let(:export) { create(:enhanced_loan_data_export, data: nil) }
+
+    # Decoy question set, should not appear anywhere.
+    let(:decoy_division) { create(:division) }
+    let(:decoy_question_set) { create(:question_set, kind: "loan_criteria", division: decoy_division) }
+    let(:decoy_question_set) { create(:question_set, kind: "loan_criteria", division: decoy_division) }
+    let(:qdattrs) { {question_set: decoy_question_set, division: decoy_division} }
+    let!(:qd1) { create(:question, qdattrs.merge(data_type: "number", label: "QD1")) }
+
+    let(:export) { create(:enhanced_loan_data_export, division: division, data: nil) }
 
     context "with criteria question set" do
       let!(:criteria) { create(:question_set, kind: "loan_criteria", division: division) }

--- a/spec/models/enhanced_loan_data_export_spec.rb
+++ b/spec/models/enhanced_loan_data_export_spec.rb
@@ -10,68 +10,92 @@ describe EnhancedLoanDataExport, type: :model do
     let!(:loan1) { create(:loan, :active, division: division) }
     let!(:loan2) { create(:loan, :active, division: division) }
     let!(:loan3) { create(:loan, :active, division: division) }
-    let!(:criteria) { create(:question_set, kind: "loan_criteria", division: division) }
-    let!(:post_analysis) { create(:question_set, kind: "loan_post_analysis", division: division) }
-    let(:qcattrs) { {question_set: criteria, division: division} }
-    let!(:qc1) { create(:question, qcattrs.merge(data_type: "boolean", label: "QC1")) }
-    let!(:qc2) { create(:question, qcattrs.merge(data_type: "percentage", label: "QC2")) }
-    let!(:qc4) { create(:question, :with_url, qcattrs.merge(data_type: "rating", label: "QC4")) }
-    let!(:qc3) { create(:question, qcattrs.merge(data_type: "text", label: "QC3")) }
-    let(:qpattrs) { {question_set: post_analysis, division: division} }
-    let!(:qp1) { create(:question, :with_url, qpattrs.merge(data_type: "number", label: "QP1")) }
-    let!(:r1_c) do
-      create(:response_set,
-             question_set: criteria,
-             loan: loan1,
-             custom_data: {
-               qc1.id.to_s => {boolean: "yes", not_applicable: "no"},
-               qc2.id.to_s => {number: "10", not_applicable: "no"},
-               qc3.id.to_s => {text: "foo\nbar", not_applicable: "no"},
-               qc4.id.to_s => {rating: "4", url: "https://example.com/1", not_applicable: "no"}
-             })
-    end
-    let!(:r1_p) do
-      create(:response_set,
-             question_set: post_analysis,
-             loan: loan1,
-             custom_data: {
-               qp1.id.to_s => {number: "7", not_applicable: "no"}
-             })
-    end
-    let!(:r2_c) do
-      create(:response_set,
-             question_set: criteria,
-             loan: loan2,
-             custom_data: {
-               qc1.id.to_s => {boolean: "", not_applicable: "yes"},
-               qc2.id.to_s => {number: "20", not_applicable: "no"},
-               qc3.id.to_s => {text: "lorp", not_applicable: "no"},
-               qc4.id.to_s => {rating: "", url: "", not_applicable: "yes"}
-             })
-    end
-    let!(:r3_p) do
-      create(:response_set,
-             question_set: post_analysis,
-             loan: loan3,
-             custom_data: {
-               qp1.id.to_s => {number: "99.9", not_applicable: "no"}
-             })
-    end
-    let!(:export) { create(:enhanced_loan_data_export, data: nil) }
+    let(:export) { create(:enhanced_loan_data_export, data: nil) }
 
-    it "should create correct data attr" do
-      export.process_data
-      base_headers = StandardLoanDataExport::HEADERS
-      base_headers = base_headers.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
-      expect(export.data[0]).to eq(base_headers + ["QC2", "QC4", "QP1"])
-      expect(export.data[1])
-        .to eq(["Question ID"] + ([nil] * (base_headers.size - 1)) + [qc2, qc4, qp1].map(&:id).map(&:to_s))
+    context "with criteria question set" do
+      let!(:criteria) { create(:question_set, kind: "loan_criteria", division: division) }
+      let(:qcattrs) { {question_set: criteria, division: division} }
+      let!(:qc1) { create(:question, qcattrs.merge(data_type: "boolean", label: "QC1")) }
+      let!(:qc2) { create(:question, qcattrs.merge(data_type: "percentage", label: "QC2")) }
+      let!(:qc4) { create(:question, :with_url, qcattrs.merge(data_type: "rating", label: "QC4")) }
+      let!(:qc3) { create(:question, qcattrs.merge(data_type: "text", label: "QC3")) }
 
-      row1 = ["10", "4", "7"]
-      row2 = ["20", ""]
-      row3 = [nil, nil, "99.9"]
-      enhanced_data = export.data[2..-1].map { |row| row[base_headers.size..-1] }
-      expect(enhanced_data).to contain_exactly(row1, row2, row3)
+      let!(:r1_c) do
+        create(:response_set,
+               question_set: criteria,
+               loan: loan1,
+               custom_data: {
+                 qc1.id.to_s => {boolean: "yes", not_applicable: "no"},
+                 qc2.id.to_s => {number: "10", not_applicable: "no"},
+                 qc3.id.to_s => {text: "foo\nbar", not_applicable: "no"},
+                 qc4.id.to_s => {rating: "4", url: "https://example.com/1", not_applicable: "no"}
+               })
+      end
+      let!(:r2_c) do
+        create(:response_set,
+               question_set: criteria,
+               loan: loan2,
+               custom_data: {
+                 qc1.id.to_s => {boolean: "", not_applicable: "yes"},
+                 qc2.id.to_s => {number: "20", not_applicable: "no"},
+                 qc3.id.to_s => {text: "lorp", not_applicable: "no"},
+                 qc4.id.to_s => {rating: "", url: "", not_applicable: "yes"}
+               })
+      end
+
+      it "should create correct data attr" do
+        export.process_data
+        base_headers = StandardLoanDataExport::HEADERS
+        base_headers = base_headers.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
+        question_id_row_nils = [nil] * (base_headers.size - 1)
+        expect(export.data[0]).to eq(base_headers + ["QC2", "QC4"])
+        expect(export.data[1])
+          .to eq(["Question ID"] + question_id_row_nils + [qc2, qc4].map(&:id))
+
+        row1 = ["10", "4"]
+        row2 = ["20", ""]
+        row3 = []
+        response_data = export.data[2..-1].map { |row| row[base_headers.size..-1] }
+        expect(response_data).to contain_exactly(row1, row2, row3)
+      end
+
+      context "with criteria and post_analysis" do
+        let!(:post_analysis) { create(:question_set, kind: "loan_post_analysis", division: division) }
+        let(:qpattrs) { {question_set: post_analysis, division: division} }
+        let!(:qp1) { create(:question, :with_url, qpattrs.merge(data_type: "number", label: "QP1")) }
+        let!(:r1_p) do
+          create(:response_set,
+                 question_set: post_analysis,
+                 loan: loan1,
+                 custom_data: {
+                   qp1.id.to_s => {number: "7", not_applicable: "no"}
+                 })
+        end
+        let!(:r3_p) do
+          create(:response_set,
+                 question_set: post_analysis,
+                 loan: loan3,
+                 custom_data: {
+                   qp1.id.to_s => {number: "99.9", not_applicable: "no"}
+                 })
+        end
+
+        it "should create correct data attr" do
+          export.process_data
+          base_headers = StandardLoanDataExport::HEADERS
+          base_headers = base_headers.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
+          question_id_row_nils = [nil] * (base_headers.size - 1)
+          expect(export.data[0]).to eq(base_headers + ["QC2", "QC4", "QP1"])
+          expect(export.data[1])
+            .to eq(["Question ID"] + question_id_row_nils + [qc2, qc4, qp1].map(&:id))
+
+          row1 = ["10", "4", "7"]
+          row2 = ["20", ""]
+          row3 = [nil, nil, "99.9"]
+          response_data = export.data[2..-1].map { |row| row[base_headers.size..-1] }
+          expect(response_data).to contain_exactly(row1, row2, row3)
+        end
+      end
     end
   end
 end

--- a/spec/models/enhanced_loan_data_export_spec.rb
+++ b/spec/models/enhanced_loan_data_export_spec.rb
@@ -42,7 +42,7 @@ describe EnhancedLoanDataExport, type: :model do
 
     it "should create correct data attr" do
       export.process_data
-      base_headers = described_class::BASE_HEADERS
+      base_headers = StandardLoanDataExport::HEADERS
       base_headers = base_headers.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
       expect(export.data[0]).to eq(base_headers + ["Q2"])
       expect(export.data[1]).to eq(["Question ID"] + ([nil] * (base_headers.size - 1)) + [q2.id.to_s])

--- a/spec/models/enhanced_loan_data_export_spec.rb
+++ b/spec/models/enhanced_loan_data_export_spec.rb
@@ -22,8 +22,8 @@ describe EnhancedLoanDataExport, type: :model do
       let(:qcattrs) { {question_set: criteria, division: division} }
       let!(:qc1) { create(:question, qcattrs.merge(data_type: "boolean", label: "QC1")) }
       let!(:qc2) { create(:question, qcattrs.merge(data_type: "percentage", label: "QC2")) }
-      let!(:qc4) { create(:question, :with_url, qcattrs.merge(data_type: "rating", label: "QC4")) }
       let!(:qc3) { create(:question, qcattrs.merge(data_type: "text", label: "QC3")) }
+      let!(:qc4) { create(:question, :with_url, qcattrs.merge(data_type: "rating", label: "QC4")) }
 
       let!(:r1_c) do
         create(:response_set,

--- a/spec/models/enhanced_loan_data_export_spec.rb
+++ b/spec/models/enhanced_loan_data_export_spec.rb
@@ -10,6 +10,11 @@ describe EnhancedLoanDataExport, type: :model do
     let!(:loan1) { create(:loan, :active, division: division) }
     let!(:loan2) { create(:loan, :active, division: division) }
     let!(:loan3) { create(:loan, :active, division: division) }
+    let(:base_headers) do
+      StandardLoanDataExport::HEADERS.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
+    end
+    let(:id_row_nils) { [nil] * (base_headers.size - 1) }
+    let(:response_data) { export.data[2..-1].map { |row| row[base_headers.size..-1] } }
     let(:export) { create(:enhanced_loan_data_export, data: nil) }
 
     context "with criteria question set" do
@@ -45,17 +50,12 @@ describe EnhancedLoanDataExport, type: :model do
 
       it "should create correct data attr" do
         export.process_data
-        base_headers = StandardLoanDataExport::HEADERS
-        base_headers = base_headers.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
-        question_id_row_nils = [nil] * (base_headers.size - 1)
         expect(export.data[0]).to eq(base_headers + ["QC2", "QC4"])
-        expect(export.data[1])
-          .to eq(["Question ID"] + question_id_row_nils + [qc2, qc4].map(&:id))
+        expect(export.data[1]).to eq(["Question ID"] + id_row_nils + [qc2, qc4].map(&:id))
 
         row1 = ["10", "4"]
         row2 = ["20", ""]
         row3 = []
-        response_data = export.data[2..-1].map { |row| row[base_headers.size..-1] }
         expect(response_data).to contain_exactly(row1, row2, row3)
       end
 
@@ -82,17 +82,12 @@ describe EnhancedLoanDataExport, type: :model do
 
         it "should create correct data attr" do
           export.process_data
-          base_headers = StandardLoanDataExport::HEADERS
-          base_headers = base_headers.map { |h| I18n.t("standard_loan_data_exports.headers.#{h}") }
-          question_id_row_nils = [nil] * (base_headers.size - 1)
           expect(export.data[0]).to eq(base_headers + ["QC2", "QC4", "QP1"])
-          expect(export.data[1])
-            .to eq(["Question ID"] + question_id_row_nils + [qc2, qc4, qp1].map(&:id))
+          expect(export.data[1]).to eq(["Question ID"] + id_row_nils + [qc2, qc4, qp1].map(&:id))
 
           row1 = ["10", "4", "7"]
           row2 = ["20", ""]
           row3 = [nil, nil, "99.9"]
-          response_data = export.data[2..-1].map { |row| row[base_headers.size..-1] }
           expect(response_data).to contain_exactly(row1, row2, row3)
         end
       end

--- a/spec/models/standard_loan_data_export_spec.rb
+++ b/spec/models/standard_loan_data_export_spec.rb
@@ -100,7 +100,7 @@ describe StandardLoanDataExport, type: :model do
     describe "error handling" do
       before do
         @times_called = 0
-        expect(export).to receive(:loan_data_as_hash).exactly(3).times do
+        expect(export).to receive(:object_data_as_hash).exactly(3).times do
           @times_called += 1
           if @times_called == 0
             {loan_id: "1", name: "A", cooperative: "Z"} # generic data row


### PR DESCRIPTION
- Refactors data export classes to eliminate copied code.
- Improves performance of data exports by replacing O(N) header index lookup with O(1).
- Adds text, boolean, not applicable to data exports.
- Cleans up and comments on confusing sets of different data types and value types in Question and Response classes.
- Adds missing spec for enhanced export
- Restricts exported data to current division
- Restricts exported question sets to those related to the exported loans

Could use some QA to ensure that the division gets correctly passed into the export object and that the export looks ok with real live data. 