### PR TITLE
3.31 qa fix to displaying task errors from data export task

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -27,7 +27,8 @@ class DataExport < ApplicationRecord
       begin
         data << hash_to_row(object_data_as_hash(object))
       rescue => e
-        @child_errors << {object_id: object.id, message: e.message}
+        # TODO generalize here and in task show if non-loans exported
+        @child_errors << {loan_id: object.id, message: e.message}
         next
       end
     end

--- a/spec/models/accounting/qb/journal_entry_extractor_spec.rb
+++ b/spec/models/accounting/qb/journal_entry_extractor_spec.rb
@@ -138,8 +138,8 @@ describe Accounting::QB::JournalEntryExtractor, type: :model do
       end
 
       it 'updates correctly in Madeline' do
-        expect(txn.line_items.map(&:qb_line_id)).to eq([0, 1, 2])
-        expect(txn.line_items.map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit'])
+        expect(txn.line_items.map(&:qb_line_id).sort).to eq([0, 1, 2])
+        expect(txn.line_items.order(:qb_line_id).map(&:posting_type)).to eq(['Credit', 'Credit', 'Debit'])
         expect_line_item_amounts([10.99, 0.81, 11.80])
         expect(txn.amount).to equal_money(11.80)
       end


### PR DESCRIPTION
task view is depending on data export rows each being loans. data export code had been generalized and  the 'object_id' key in custom_error_data was clashing with expected 'loan_id' key in task show html. Since a larger overhaul would be needed to generalize task show, i reverted the key to 'loan_id' in data export and added a TODO note for if data exports are generalized beyond loans. 