### PR TITLE
Harmonize person and organization dropdown scoping

### DIFF
--- a/app/controllers/admin/basic_projects_controller.rb
+++ b/app/controllers/admin/basic_projects_controller.rb
@@ -105,7 +105,7 @@ class Admin::BasicProjectsController < Admin::ProjectsController
 
   def prep_form_vars
     @tab ||= "details"
-    @agent_choices = policy_scope(Person).in_division(selected_division).with_system_access.order(:name)
+    @agent_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
   end
 
   def basic_project_params

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -150,8 +150,8 @@ module Admin
 
     def prep_form_vars
       @tab ||= "details"
-      @organization_choices = organization_policy_scope(Organization.in_division(selected_division)).order(:name)
-      @agent_choices = policy_scope(Person).in_division(selected_division).with_system_access.order(:name)
+      @org_choices = Organization.in_ancestor_or_descendant_division(selected_division_or_root).by_name
+      @agent_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
       @currency_choices = Currency.all.order(:name)
       @txn_mode_choices = txn_mode_options
       prep_criteria

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -91,7 +91,7 @@ class Admin::OrganizationsController < Admin::AdminController
 
   def prep_form_vars
     @countries = Country.order(:name)
-    @people_choices = person_policy_scope(Person.all).order(:name)
+    @people_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
     @notes = @org.notes.order(created_at: :desc)
 
     @loans_grid = initialize_grid(

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -92,17 +92,13 @@ module Admin
 
     def prep_form_vars
       @countries = Country.order(:name)
-      @organization_choices = organization_choices
+      @org_choices = Organization.in_ancestor_or_descendant_division(selected_division_or_root).by_name
       @roles_choices = role_choices
       @notes = @person.notes.order(created_at: :desc)
     end
 
     def role_choices
       Person::VALID_DIVISION_ROLES
-    end
-
-    def organization_choices
-      organization_policy_scope(Organization.in_division(selected_division)).order(:name)
     end
   end
 end

--- a/app/controllers/admin/project_logs_controller.rb
+++ b/app/controllers/admin/project_logs_controller.rb
@@ -68,8 +68,7 @@ class Admin::ProjectLogsController < Admin::AdminController
       render json: {summary: @log.summary, logId: @log.id}, status: 200
       LogNotificationJob.perform_later(@log) if params[:notify] == '1'
     else
-      @progress_metrics = ProjectLog.progress_metric_options
-      @people = Person.by_name
+      set_log_form_vars
       render partial: 'modal_content', status: :unprocessable_entity
     end
   end

--- a/app/controllers/admin/project_steps_controller.rb
+++ b/app/controllers/admin/project_steps_controller.rb
@@ -203,7 +203,7 @@ class Admin::ProjectStepsController < Admin::AdminController
     @mode = params[:action] == "show" ? :show_and_form : :form_only
     @project = @step.project
     @parents = @step.project.timeline_groups_preordered
-    @agents = policy_scope(Person).in_division(selected_division).with_system_access.order(:name)
+    @agent_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
     @precedents = @step.project.timeline_entries.where("type = 'ProjectStep' AND id != ?", @step.id || 0).by_date
     render partial: "/admin/project_steps/modal_content", status: status, locals: {
       context: params[:context]

--- a/app/controllers/concerns/log_controllable.rb
+++ b/app/controllers/concerns/log_controllable.rb
@@ -5,7 +5,7 @@ module LogControllable
 
   def set_log_form_vars
     @progress_metrics = ProjectLog.progress_metric_options
-    @people = Person.by_name
+    @people_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
   end
 
   def authorize_and_render_modal

--- a/app/models/concerns/division_based.rb
+++ b/app/models/concerns/division_based.rb
@@ -3,7 +3,11 @@ module DivisionBased
 
   included do
     def self.in_division(division)
-      division ? where(division: division.self_and_descendants) : all
+      division ? where(division_id: division.self_and_descendant_ids) : all
+    end
+
+    def self.in_ancestor_or_descendant_division(division)
+      where(division_id: division.self_and_descendant_ids + division.ancestor_ids)
     end
 
     # For wicegrid custom filters

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -45,7 +45,7 @@ class Division < ApplicationRecord
 
   before_validation :generate_short_name
 
-  scope :by_name, -> { Arel.sql(order("LOWER(divisions.name)")) }
+  scope :by_name, -> { order(Arel.sql("LOWER(divisions.name)")) }
   scope :published, -> { where(public: true) }
 
   delegate :connected?, to: :qb_connection, prefix: :quickbooks, allow_nil: true

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,6 +12,8 @@ class Organization < ApplicationRecord
   has_many :loans, dependent: :destroy
   has_many :people, foreign_key: :primary_organization_id, dependent: :nullify
 
+  scope :by_name, -> { order(Arel.sql("LOWER(organizations.name)")) }
+
   attr_option_settable :inception
 
   validates :name, :division, :country, presence: true

--- a/app/views/admin/loans/_form.html.slim
+++ b/app/views/admin/loans/_form.html.slim
@@ -26,7 +26,7 @@
     span = @loan.division.try(:name)
 
   = authorized_form_field(simple_form: f, model: @loan, field_name: :organization,
-    choices: @organization_choices, include_blank_choice: true, classes: 'hidden-print',
+    choices: @org_choices, include_blank_choice: true, classes: 'hidden-print',
     form_identifier: form_identifier, popover_options: popover_options)
 
   = f.input t('activerecord.attributes.loan.organization'), wrapper_html: {class: 'visible-print-block'}

--- a/app/views/admin/people/_form.html.slim
+++ b/app/views/admin/people/_form.html.slim
@@ -23,7 +23,7 @@
     .view-element
       - if @person.primary_organization
         = link_to @person.primary_organization.name, admin_organization_path(@person.primary_organization)
-    = f.input_field :primary_organization_id, collection: @organization_choices, include_blank: true
+    = f.input_field :primary_organization_id, collection: @org_choices, include_blank: true
 
   = f.input :first_name
     .view-element = @person.first_name

--- a/app/views/admin/project_logs/_fields.html.slim
+++ b/app/views/admin/project_logs/_fields.html.slim
@@ -10,7 +10,7 @@
         => check_box_tag(:step_completed_on_date)
         = t('log.step_completed')
 
-  = f.input :agent_id, include_blank: true, collection: @people
+  = f.input :agent_id, include_blank: true, collection: @people_choices
   = f.input :progress_metric_value, collection: @progress_metrics
 
   = render 'admin/project_logs/translatable', log: @log, f: f

--- a/app/views/admin/project_steps/_modal_content.html.slim
+++ b/app/views/admin/project_steps/_modal_content.html.slim
@@ -74,7 +74,7 @@ section.step-fields class=(@mode == :show_and_form ? 'show-view' : 'edit-view') 
 
       = f.input :agent_id
         .view-element = @step.agent.try(:name)
-        = f.input_field :agent_id, collection: @agents, include_blank: true
+        = f.input_field :agent_id, collection: @agent_choices, include_blank: true
 
       // Two column details section
       br


### PR DESCRIPTION
Maxi found an issue with the migrated data in which he couldn't select the person he wanted from the Loan Primary Agent dropdown.

I audited the code and found that in some places (organization primary contact, project log agent), the list of people is scoped, showing every person in all of Madeline, whereas in other places (loan/project agent, project step agent), the available list of users was being scoped to those whose home division is in the selected division plus its descendants.
Neither of these is optimal. In the former case, you end up with tons of users from divisions you don't care about at all.

In the latter case, you end up not being able to assign e.g. someone from La Base Argentina as agent for a CONAMI (subdivision) loan. This is specifically required for the migration. Right now, most of the loans in CONAMI show no agent if you edit them, even though there is one, because the option is not available in the dropdown. This will lead to data loss as soon as someone saves the loan.

The same is true for organization dropdowns. There is one case in the code (people.primary_organization_id) where the list of orgs is scoped to division. But on the organization form, in the select2 dropdown for "Members", you can select any user in the system, so that way you can associate any user to any org.

One other thing I noted is that in some cases, the policy scope is being applied to these, whereas in other cases it's not. I think it's more correct to NOT apply it, since the policy scope is meant to control which objects the current user can list in an index view, not in a form dropdown. If a record has a value saved on it already, and the current user is allowed to edit that record, it does not make sense to restrict the dropdown scope such that data gets lost when the record is saved by that user.

To correct all the above, this PR:

* Removes all the policy scoping
* Changes the division-scoped people and org dropdowns to include people from both descendant AND ancestor divisions (this would enable the Argentina/CONAMI use case above)
* Change the unscoped people and org dropdowns to the same thing

I took a look at whether there is any data that would get impinged upon by scoping the currently unscoped dropdowns. There are just 3-4 few rows for each case. We will need to give these to Brendan and ask him to clean them up manually.

This PR has been fully QA'd on my local machine with a production DB clone.

Details below:

```
# SET 1
These are members who have a primary organization that is not in an ancestor or descendant division.

madeline_system_production=> select o.id, o.division_id, o.name, p.id, p.division_id, p.first_name, p.last_name from organizations o inner join people p on o.id = p.primary_organization_id where not exists (select * from division_hierarchies dh where dh.ancestor_id = o.division_id and dh.descendant_id = p.division_id or dh.ancestor_id = p.division_id and dh.descendant_id = o.division_id);
  id  | division_id |              name               |  id  | division_id | first_name |  last_name  
------+-------------+---------------------------------+------+-------------+------------+-------------
  764 |         102 | Cabit - Austin Taxi Cooperative | 1267 |          11 | Bhairavi   | Desai
  851 |           2 | Test Co-op                      | 1359 |         125 | Joe        | TestGuy
 1010 |          11 | Happy Daycare                   | 1383 |           2 | Smiley     | Rojas-Nunez
 1012 |          11 | Happy Daycare (M)               | 1605 |         122 | Smiley     | Rojas-Nunez
  851 |           2 | Test Co-op                      | 1619 |         103 | Devney     | Test
(5 rows)

# SET 2
These are coops who have a primary contact that is not in an ancestor or descendant division. (They are all Smiley—perhaps because he changed divisions? Not sure what should be done here.)

madeline_system_production=> select o.id, o.division_id, o.name, p.id, p.division_id, p.first_name, p.last_name from organizations o inner join people p on o.primary_contact_id = p.id where not exists (select * from division_hierarchies dh where dh.ancestor_id = o.division_id and dh.descendant_id = p.division_id or dh.ancestor_id = p.division_id and dh.descendant_id = o.division_id);
  id  | division_id |       name        |  id  | division_id | first_name |  last_name  
------+-------------+-------------------+------+-------------+------------+-------------
 1009 |          11 | Easy Sliders Inc  | 1383 |           2 | Smiley     | Rojas-Nunez
 1010 |          11 | Happy Daycare     | 1605 |         122 | Smiley     | Rojas-Nunez
 1012 |          11 | Happy Daycare (M) | 1605 |         122 | Smiley     | Rojas-Nunez
(3 rows)

# SET 3
These are logs that have an agent that is not in an ancestor or descendant division or the corresponding loan. (Loan ID is second column).

madeline_system_production=> select logs.id, loans.id, loans.division_id, loans.name, p.id, p.division_id, p.first_name, p.last_name from project_logs logs inner join timeline_entries te on te.id = logs.project_step_id inner join projects loans on loans.id = te.project_id inner join people p on logs.agent_id = p.id where not exists (select * from division_hierarchies dh where dh.ancestor_id = loans.division_id and dh.descendant_id = p.division_id or dh.ancestor_id = p.division_id and dh.descendant_id = loans.division_id) and loans.division_id not in (2,4,13);
  id   |  id  | division_id |                                     name                                     |  id  | division_id | first_name | last_name 
-------+------+-------------+------------------------------------------------------------------------------+------+-------------+------------+-----------
 15571 | 1002 |         103 |                                                                              |  173 |          11 | Rafay      | Khalid
 20336 | 1205 |         104 | Loan to Execute Marketing Plan                                               |  207 |          11 | Christyne  | Dillard
 24684 | 1271 |          11 |                                                                              |  183 |           2 | Gabriel    | Guerrero
 38013 | 3265 |         159 | Chicago Chifresh food service - purchase of real estate to expend operations | 1626 |          11 | Barry      | Pinckney
(4 rows)

# DIVISIONS
This is a table of divisions encountered above, just for reference.

 madeline_system_production=# select id, name from divisions where id in (102, 2, 11, 125, 122, 103, 104, 159) order by id;
 id  |                        name                        
-----+----------------------------------------------------
   2 | La Base Argentina
  11 | The Working World
 102 | SRLF
 103 | Baltimore Roundtable for Economic Democracy (BRED)
 104 | LA Coop Lab
 122 | NEW West Virginia
 125 | PACA
 159 | Illinois Worker Cooperative Alliance
(8 rows)

```


SEE ALSO: https://github.com/sassafrastech/madeline/pull/937/files