### PR TITLE
Fix division refs in dropdown scoping

### DIFF
--- a/app/controllers/admin/basic_projects_controller.rb
+++ b/app/controllers/admin/basic_projects_controller.rb
@@ -105,7 +105,7 @@ class Admin::BasicProjectsController < Admin::ProjectsController
 
   def prep_form_vars
     @tab ||= "details"
-    @agent_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
+    @agent_choices = Person.in_ancestor_or_descendant_division(@basic_project.division).by_name
   end
 
   def basic_project_params

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -150,8 +150,8 @@ module Admin
 
     def prep_form_vars
       @tab ||= "details"
-      @org_choices = Organization.in_ancestor_or_descendant_division(selected_division_or_root).by_name
-      @agent_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
+      @org_choices = Organization.in_ancestor_or_descendant_division(@loan.division).by_name
+      @agent_choices = Person.in_ancestor_or_descendant_division(@loan.division).by_name
       @currency_choices = Currency.all.order(:name)
       @txn_mode_choices = txn_mode_options
       prep_criteria

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -91,7 +91,7 @@ class Admin::OrganizationsController < Admin::AdminController
 
   def prep_form_vars
     @countries = Country.order(:name)
-    @people_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
+    @people_choices = Person.in_ancestor_or_descendant_division(@org.division).by_name
     @notes = @org.notes.order(created_at: :desc)
 
     @loans_grid = initialize_grid(

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -92,7 +92,7 @@ module Admin
 
     def prep_form_vars
       @countries = Country.order(:name)
-      @org_choices = Organization.in_ancestor_or_descendant_division(selected_division_or_root).by_name
+      @org_choices = Organization.in_ancestor_or_descendant_division(@person.division).by_name
       @roles_choices = role_choices
       @notes = @person.notes.order(created_at: :desc)
     end

--- a/app/controllers/admin/project_steps_controller.rb
+++ b/app/controllers/admin/project_steps_controller.rb
@@ -203,7 +203,7 @@ class Admin::ProjectStepsController < Admin::AdminController
     @mode = params[:action] == "show" ? :show_and_form : :form_only
     @project = @step.project
     @parents = @step.project.timeline_groups_preordered
-    @agent_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
+    @agent_choices = Person.in_ancestor_or_descendant_division(@step.division).by_name
     @precedents = @step.project.timeline_entries.where("type = 'ProjectStep' AND id != ?", @step.id || 0).by_date
     render partial: "/admin/project_steps/modal_content", status: status, locals: {
       context: params[:context]

--- a/app/controllers/concerns/log_controllable.rb
+++ b/app/controllers/concerns/log_controllable.rb
@@ -5,7 +5,7 @@ module LogControllable
 
   def set_log_form_vars
     @progress_metrics = ProjectLog.progress_metric_options
-    @people_choices = Person.in_ancestor_or_descendant_division(selected_division_or_root).by_name
+    @people_choices = Person.in_ancestor_or_descendant_division(@log.division).by_name
   end
 
   def authorize_and_render_modal


### PR DESCRIPTION
I realized that I should have been using the record's division and not the currently selected division when scoping this list. Sorry about the oversight. This should fix it.