### PR TITLE
12139: add created and updated at fields, fix loan type field in data…

### DIFF
--- a/app/models/standard_loan_data_export.rb
+++ b/app/models/standard_loan_data_export.rb
@@ -39,7 +39,9 @@ class StandardLoanDataExport < DataExport
     :change_in_principal,
     :change_in_interest,
     :final_principal_balance,
-    :final_interest_balance
+    :final_interest_balance,
+    :created_at,
+    :updated_at
   ]
 
   protected
@@ -73,7 +75,7 @@ class StandardLoanDataExport < DataExport
       projected_first_payment_date: loan.projected_first_payment_date,
       signing_date: loan.signing_date,
       length_months: loan.length_months,
-      loan_type: loan.type,
+      loan_type: loan.loan_type.to_s,
       currency: loan.currency&.name,
       amount: loan.amount,
       rate: loan.rate,
@@ -91,7 +93,9 @@ class StandardLoanDataExport < DataExport
       change_in_principal: loan.change_in_principal(start_date: start_date, end_date: end_date),
       change_in_interest: loan.change_in_interest(start_date: start_date, end_date: end_date),
       final_principal_balance: loan.final_principal_balance(start_date: start_date, end_date: end_date),
-      final_interest_balance: loan.final_interest_balance(start_date: start_date, end_date: end_date)
+      final_interest_balance: loan.final_interest_balance(start_date: start_date, end_date: end_date),
+      created_at: loan.created_at,
+      updated_at: loan.updated_at
     }
   end
 

--- a/config/locales/en/data_exports.en.yml
+++ b/config/locales/en/data_exports.en.yml
@@ -66,3 +66,5 @@ en:
       status: "Status"
       sum_of_disbursements: "Sum of Disbursements"
       sum_of_repayments: "Sum of Repayments"
+      created_at: "Created At"
+      updated_at: "Updated At"


### PR DESCRIPTION
… exports

In data exports, there was a bug where `loan.type` was of course yielding "Loan" since type is a Ruby or Rails method that tells the class. THis fixes that by pulling the loan.loan_type.to_s using  the existing option set and translation setup. This PR also adds created at and updated at fields for loans to the data exports.
<img width="445" alt="Screen Shot 2022-03-09 at 4 50 54 PM" src="https://user-images.githubusercontent.com/4730344/157552252-cb66e44e-0ad8-4ee1-ba55-9b98b14588bb.png">
<img width="177" alt="Screen Shot 2022-03-09 at 4 50 00 PM" src="https://user-images.githubusercontent.com/4730344/157552253-254c8b37-8be7-4eeb-896a-e2e6614db044.png">
 