### PR TITLE
12130: filter for incomplete steps on timeline by default

### DIFF
--- a/app/views/admin/basic_projects/show.html.slim
+++ b/app/views/admin/basic_projects/show.html.slim
@@ -3,8 +3,12 @@
 .basic-project
   ul.nav.nav-tabs
     - Admin::BasicProjectsController::TABS.each do |tab|
-      li role="presentation" class==("active" if tab == @tab)
-        = link_to t("basic_project.tabs.#{tab}"), admin_basic_project_tab_path(@basic_project.id, tab: tab)
+      - if tab == "timeline"
+        li role="presentation" class==("active" if tab == @tab)
+          = link_to t("basic_project.tabs.#{tab}"), admin_basic_project_tab_path(@basic_project.id, tab: tab, status: :incomplete)
+      - else
+        li role="presentation" class==("active" if tab == @tab)
+          = link_to t("basic_project.tabs.#{tab}"), admin_basic_project_tab_path(@basic_project.id, tab: tab)
 
   .block.tab-content data-tab-content=@tab
     = render "admin/basic_projects/#{@tab}", project: @basic_project

--- a/app/views/admin/loans/show.html.slim
+++ b/app/views/admin/loans/show.html.slim
@@ -6,8 +6,12 @@ section.loan.details
   div.loan-content
     ul.nav.nav-tabs.nav-tabs-responsive.hidden-print role="tablist"
       - Admin::LoansController::TABS.each do |tab|
-        li role="presentation" class==("active" if tab == @tab)
-          = link_to t("loan.tab.#{tab}"), admin_loan_tab_path(@loan.id, tab: tab)
+        - if tab == "timeline"
+          li role="presentation" class==("active" if tab == @tab)
+            = link_to t("loan.tab.#{tab}"), admin_loan_tab_path(@loan.id, tab: tab, status: :incomplete)
+        - else
+          li role="presentation" class==("active" if tab == @tab)
+            = link_to t("loan.tab.#{tab}"), admin_loan_tab_path(@loan.id, tab: tab)
 
     .tab-content
       .tab-pane.active id=@tab

--- a/app/views/admin/timeline/_top_controls.html.slim
+++ b/app/views/admin/timeline/_top_controls.html.slim
@@ -39,7 +39,7 @@ header.timeline-header.row
         class: "form-control"
 
       = select_tag :status,
-        options_for_select(@status_options),
+        options_for_select(@status_options, :incomplete),
         include_blank: I18n.t("project_step.all_completion_statuses"),
         class: "form-control"
 


### PR DESCRIPTION
An earlier attempt at this failed bc the status filter has to be set in the url. th solution here is not ideal, but is readable and works. Basic projects and loans each have their own show html. These each iterate over a TABS constant for each of those models. If the tab is "timeline" then we add the status param to the link's url. Note that routes defines a special kind of tab route, and since it is used for all of the tabs, doing the (also not ideal) override of routes in NamedRouteOverrides concern, as is done for adding params to the main nav links, was not an option.
<img width="1356" alt="Screen Shot 2022-03-09 at 4 47 05 PM" src="https://user-images.githubusercontent.com/4730344/157551887-32d566e5-9263-4e2f-a67c-ff2f68e485b0.png">
<img width="1360" alt="Screen Shot 2022-03-09 at 4 46 44 PM" src="https://user-images.githubusercontent.com/4730344/157551904-d8f5edbe-05f0-4a41-8d66-931fa8ef76fa.png">


