### PR TITLE
12323: add a contact email link to settings page

### DIFF
--- a/app/views/admin/accounting/settings/show.html.slim
+++ b/app/views/admin/accounting/settings/show.html.slim
@@ -93,3 +93,5 @@ section.block
 
   section.alert.alert-warning
     = t('quickbooks.class_location_notice')
+
+p = mail_to "madeline.ops@sassafras.coop",  t("quickbooks.support_contact")

--- a/config/locales/en/quickbooks.en.yml
+++ b/config/locales/en/quickbooks.en.yml
@@ -52,6 +52,7 @@ en:
       alert: "Attention: Switching off read-only accounting will cause Madeline to add automated transactions to QuickBooks data."
       note: "When set to read-only, transaction creation and automatic interest calculation is disabled. When not set to read-only mode, Madeline will automatically calculate interest for loans and admins may create transactions on loans. In both modes, QuickBooks data is regularly imported and available to view."
       qb_read_only: "Read-Only Accounting Data"
+    support_contact: "Email madeline.ops@sassafras.coop for support"
     update:
       update_changed: "Fetch changes from QuickBooks"
       update_queued_html: "QuickBooks fetch queued successfully, <a href='%{url}'>view progress</a>."


### PR DESCRIPTION
This adds an email link at the bottom of the Accounting Settings page to meet Intuit requirement that QB app users be able to contact us from within the app. 
<img width="1256" alt="Screen Shot 2022-11-10 at 5 44 50 PM" src="https://user-images.githubusercontent.com/4730344/201402798-49ca857e-177b-4fa3-8bb1-3ae4a01b897b.png">
