### PR TITLE
12296: ensure sensitive info endpoints always redirect with status 302

### DIFF
--- a/app/controllers/admin/accounting/quickbooks_controller.rb
+++ b/app/controllers/admin/accounting/quickbooks_controller.rb
@@ -13,7 +13,7 @@ class Admin::Accounting::QuickbooksController < Admin::AdminController
         scope: "com.intuit.quickbooks.accounting"
       )
 
-      redirect_to grant_url
+      redirect_to grant_url, status: 302
     end
   end
 
@@ -50,13 +50,13 @@ class Admin::Accounting::QuickbooksController < Admin::AdminController
 
     flash[:notice] = t('quickbooks.connection.link_message')
     flash[:alert] = t('quickbooks.connection.import_in_progress_message')
-    redirect_to admin_accounting_settings_path
+    redirect_to admin_accounting_settings_path, status: 302
   end
 
   def disconnect
     authorize :'accounting/quickbooks', :disconnect?
     Division.root.qb_connection.destroy
-    redirect_to admin_accounting_settings_path, notice: t('quickbooks.connection.disconnect_message')
+    redirect_to admin_accounting_settings_path, notice: t('quickbooks.connection.disconnect_message'), status: 302
   end
 
   def update_changed
@@ -69,7 +69,7 @@ class Admin::Accounting::QuickbooksController < Admin::AdminController
 
     flash[:notice] = t("quickbooks.update.update_queued_html", url: admin_task_path(@task))
 
-    redirect_back(fallback_location: admin_loans_path)
+    redirect_back(fallback_location: admin_loans_path, status: 302)
   end
 
   private

--- a/app/views/admin/accounting/quickbooks/oauth_callback.html.slim
+++ b/app/views/admin/accounting/quickbooks/oauth_callback.html.slim
@@ -1,3 +1,0 @@
-- content_for(:title, 'Connected to quickbooks')
-
-div You can now close this window.


### PR DESCRIPTION
This change makes all endpoints in oauth settings return 302 Found redirect, to meet the following Intuit security requirements: Web application endpoints that receive sensitive customer information and/or authentication tokens in URL parameters must not return HTML content via an HTTP Response Body. This is to prevent sensitive customer information from being accidentally leaked to 3rd parties in the subsequent HTTP Referer request headers.

Instead, the web application endpoints should implement a 302 Found redirect. This is particularly important when application end points are handling authentication tokens.

