### PR TITLE
12380 last year statement revisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ scratch.*
 *.scratch
 *.swp
 *.swo
+tx/*
 config/secrets.yml
 config/scout_apm.yml
 setenv.sh

--- a/.tx/config_20230203160909.bak
+++ b/.tx/config_20230203160909.bak
@@ -1,0 +1,10 @@
+[main]
+host = https://www.transifex.com
+
+[madeline.combined-en-yml]
+file_filter = config/locales/<lang>.yml
+minimum_perc = 0
+source_file = tmp/combined.en.yml
+source_lang = en
+type = YML
+

--- a/app/assets/stylesheets/admin/loans/statement.scss
+++ b/app/assets/stylesheets/admin/loans/statement.scss
@@ -13,6 +13,10 @@ body.admin.print-view.statement {
   display: flex;
   align-items: center;
   justify-content: center;
+  .header-logo {
+    width: 50%;
+    margin: 2em;
+  }
 }
 
 .block-container {
@@ -22,7 +26,7 @@ body.admin.print-view.statement {
 .statement-block {
   color: #383636; //seedcommons gray
   border: solid 1px #517b91; //seedcommons blue
-  padding: .5em;
+  padding: 1em;
   margin-bottom: 2em;
   p {
     margin: 0 0 0 2px;
@@ -45,7 +49,7 @@ body.admin.print-view.statement {
   display: flex;
   align-items: center;
   justify-content: center;
-  
+
   // START always hide this warning until notice from TWW
   display: none;
   // END always hide this warning until notice from TWW
@@ -71,5 +75,8 @@ body.admin.print-view.statement {
   margin-top: 2em;
   thead {
     background-color: #517b91; //seedcommons blue
+  }
+  th.date {
+    width: 110px;
   }
 }

--- a/app/assets/stylesheets/admin/loans/statement.scss
+++ b/app/assets/stylesheets/admin/loans/statement.scss
@@ -45,6 +45,11 @@ body.admin.print-view.statement {
   display: flex;
   align-items: center;
   justify-content: center;
+  
+  // START always hide this warning until notice from TWW
+  display: none;
+  // END always hide this warning until notice from TWW
+
   width: 100%;
   .fa {
     margin-right: .25em;

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -134,7 +134,7 @@ module Admin
 
     def statement
       @loan = Loan.find(params[:id])
-      authorize(@loan, :show?)
+      authorize(@loan, :statement_access?)
       @start_date = Date.parse(params[:start_date]) #Time.zone.today.last_year.beginning_of_year
       @end_date = Date.parse(params[:end_date]) #Time.zone.today.last_year.end_of_year
       @transactions = @loan.transactions.in_date_range(@start_date, @end_date).most_recent_first

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -137,7 +137,7 @@ module Admin
       authorize(@loan, :show?)
       @start_date = Date.parse(params[:start_date]) #Time.zone.today.last_year.beginning_of_year
       @end_date = Date.parse(params[:end_date]) #Time.zone.today.last_year.end_of_year
-      @transactions = @loan.transactions.in_date_range(@start_date, @end_date)
+      @transactions = @loan.transactions.in_date_range(@start_date, @end_date).most_recent_first
       @print_view = true
       @for_statement = true
       @is_draft = @loan.division.shared_closed_books_date.nil? || @end_date > @loan.division.shared_closed_books_date

--- a/app/policies/loan_policy.rb
+++ b/app/policies/loan_policy.rb
@@ -13,6 +13,10 @@ class LoanPolicy < ProjectPolicy
     division_admin(division: Division.root)
   end
 
+  def statement_access?
+    division_admin(division: Division.root)
+  end
+
   class Scope < DivisionOwnedScope
     def resolve
       if user # madeline, so use divisionowned

--- a/app/views/admin/loans/_transactions.html.slim
+++ b/app/views/admin/loans/_transactions.html.slim
@@ -24,6 +24,9 @@ section.transactions
           ul.dropdown-menu.dropdown-menu-right.print-actions
             li = link_to(t('statement.last_year_statement'), statement_admin_loan_url(start_date: Time.zone.today.last_year.beginning_of_year, end_date: Time.zone.today.last_year.end_of_year),
               data: {project_id: @loan.id}, target: '_blank')
+            li.divider role="separator"
+            li = link_to(t('statement.historical'), statement_admin_loan_url(start_date: (@loan.signing_date || Date.parse("01-01-2000")), end_date: Time.zone.today),
+              data: {project_id: @loan.id}, target: '_blank')
             /! # links to add'l statements, waiting for go ahead (Jan 2023)
               li.divider role="separator"
               - @loan.annual_statement_ranges.each do |range|

--- a/app/views/admin/loans/_transactions.html.slim
+++ b/app/views/admin/loans/_transactions.html.slim
@@ -15,7 +15,7 @@ section.transactions
           = link_to sync_admin_accounting_transactions_path(project_id: @loan.id), data: {action: "sync-data"}, method: :post
               i.fa.fa-pencil.fa-large>
               = t(".sync_data")
-      - if @loan.transactions.count > 0 && policy(@sample_transaction).show?
+      - if @loan.transactions.count > 0 && policy(@loan).statement_access?
         span.dropdown
           a.dropdown-toggle aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#" role="button"
             i.fa.fa-print>

--- a/app/views/admin/loans/statement.html.slim
+++ b/app/views/admin/loans/statement.html.slim
@@ -12,7 +12,7 @@ div.statement
       p.coop-name #{@loan.organization.name}
       p #{t("statement.contract_loan_amount")}: #{format_currency(@loan.amount, @loan.currency, tooltip: false)}
       p #{t("statement.interest_rate")}: #{@loan.rate}
-      p #{@loan.name}
+      p #{t("statement.loan_id")}: #{@loan.id}
 
 
     div.statement-block.statement-dates

--- a/app/views/admin/loans/statement.html.slim
+++ b/app/views/admin/loans/statement.html.slim
@@ -1,9 +1,9 @@
-- content_for(:title, t("statement.title", name: @loan.name, start_date: @start_date, end_date:@end_date))
+- content_for(:title, t("statement.title", name: @loan.id, start_date: @start_date, end_date:@end_date))
 
 div.statement
   div.statement-header
     - if @loan.top_level_division.try(:logo).present?
-      = image_tag @loan.top_level_division.logo.url(:banner)
+      = image_tag(@loan.top_level_division.logo.url(:banner), class: "header-logo")
     - else
       h1 #{@loan.top_level_division.try(:name) || @loan.division.name}
 
@@ -28,23 +28,23 @@ div.statement
 
     thead
         tr
-          th #{t("statement.headers.date")}
-          th #{t("statement.headers.type")}
-          th #{t("statement.headers.description")}
-          th #{t("statement.headers.vendor")}
-          th #{t("statement.headers.amount")}
-          th #{t("statement.headers.change_in_interest")}
-          th #{t("statement.headers.change_in_principal")}
-          th #{t("statement.headers.interest_balance")}
-          th #{t("statement.headers.principal_balance")}
-          th #{t("statement.headers.total_balance")}
+          th.date #{t("statement.headers.date")}
+          th.type #{t("statement.headers.type")}
+          th.vendor #{t("statement.headers.vendor")}
+          th.description #{t("statement.headers.description")}
+          th.amount #{t("statement.headers.amount")}
+          th.money #{t("statement.headers.change_in_interest")}
+          th.money #{t("statement.headers.change_in_principal")}
+          th.money #{t("statement.headers.interest_balance")}
+          th.money #{t("statement.headers.principal_balance")}
+          th.money #{t("statement.headers.total_balance")}
     tbody
       - @transactions.each do |t|
         tr
-          td = "#{t.txn_date}"
+          td = "#{ldate(t.txn_date, format: "%b %-d, %Y")}"
           td = "#{t.loan_transaction_type_label}"
-          td = "#{t.description}"
           td = "#{t.vendor.try(:name)}"
+          td = "#{t.description}"
           td = "#{format_currency(t.amount, t.currency, tooltip: false)}"
           td = "#{format_currency(t.change_in_interest, t.currency, tooltip: false)}"
           td = "#{format_currency(t.change_in_principal, t.currency, tooltip: false)}"

--- a/app/views/admin/loans/statement.html.slim
+++ b/app/views/admin/loans/statement.html.slim
@@ -10,7 +10,7 @@ div.statement
   div.block-container
     div.statement-block.loan-info
       p.coop-name #{@loan.organization.name}
-      p #{t("statement.contract_loan_amount")}: #{@loan.amount}
+      p #{t("statement.contract_loan_amount")}: #{format_currency(@loan.amount, @loan.currency, tooltip: false)}
       p #{t("statement.interest_rate")}: #{@loan.rate}
       p #{@loan.name}
 

--- a/config/locales/en/statement.en.yml
+++ b/config/locales/en/statement.en.yml
@@ -3,6 +3,7 @@ en:
     annual: "%{year} Statement"
     contract_loan_amount: "Contract Loan Amount"
     draft_warning: "WARNING: This is a DRAFT. Information subject to change."
+    historical: "Historical Loan Schedule"
     interest_rate: "Interest Rate"
     last_year_statement: "Statement for Last Year"
     loan_id: "Loan ID"

--- a/config/locales/en/statement.en.yml
+++ b/config/locales/en/statement.en.yml
@@ -5,6 +5,7 @@ en:
     draft_warning: "WARNING: This is a DRAFT. Information subject to change."
     interest_rate: "Interest Rate"
     last_year_statement: "Statement for Last Year"
+    loan_id: "Loan ID"
     loan_statement: "Loan Statement"
     headers:
       amount: "Amount"

--- a/config/locales/en/statement.en.yml
+++ b/config/locales/en/statement.en.yml
@@ -25,4 +25,4 @@ en:
       type: "Type"
       vendor: "Vendor"
     quarterly: "%{quarter} Statement %{year}"
-    title: "Statement for %{name}, %{start_date} - %{end_date}"
+    title: "Loan %{name} Statement %{start_date} - %{end_date}"

--- a/spec/system/admin/accounting/loan_statement_flow_spec.rb
+++ b/spec/system/admin/accounting/loan_statement_flow_spec.rb
@@ -103,7 +103,8 @@ describe "loan statement flow", :accounting do
             end
           end
 
-          context "end date is after closed books date" do
+          # TODO: turn this spec back on when draft msg styles updated from display:none
+          xcontext "end date is after closed books date" do
             before do
               division.root.update(closed_books_date:Time.zone.now.last_year.beginning_of_year)
             end

--- a/spec/system/admin/accounting/loan_statement_flow_spec.rb
+++ b/spec/system/admin/accounting/loan_statement_flow_spec.rb
@@ -93,11 +93,11 @@ describe "loan statement flow", :accounting do
               expect(page).not_to have_content("too old")
               expect(page).not_to have_content("too recent")
 
-              within(:xpath, "//table/tbody/tr[1]/td[3]") do
+              within(:xpath, "//table/tbody/tr[1]/td[4]") do
                 expect(page).to have_content('most recent of last year')
               end
 
-              within(:xpath, "//table/tbody/tr[3]/td[3]") do
+              within(:xpath, "//table/tbody/tr[3]/td[4]") do
                 expect(page).to have_content('oldest of last year')
               end
             end

--- a/spec/system/admin/accounting/loan_statement_flow_spec.rb
+++ b/spec/system/admin/accounting/loan_statement_flow_spec.rb
@@ -93,7 +93,6 @@ describe "loan statement flow", :accounting do
               expect(page).not_to have_content("too old")
               expect(page).not_to have_content("too recent")
 
-              save_and_open_page
               within(:xpath, "//table/tbody/tr[1]/td[3]") do
                 page.should have_content('most recent of last year')
               end
@@ -113,6 +112,7 @@ describe "loan statement flow", :accounting do
               click_on "Print Loan Statement"
               new_window = window_opened_by { click_link "Statement for Last Year" }
               within_window new_window do
+                save_and_open_page
                 expect(page).to have_content("DRAFT")
               end
             end


### PR DESCRIPTION
Reorder dates so chronology is correct (Jan/earliest to Dec/latest)
Manually remove “Draft message” (revisit end of Feb/when Zahuna msgs us!)
“Print loan schedule” link only appears for root division admin
replace loan name with loan ID
add “Historical loan schedule” link containing all loans for all time (revisit end of Feb/when Zahuna msgs us)
css on the date col that keeps the date from wrapping in landscape (wraps in portrait)