### PR TITLE
12387 loan statement within day order and interest accrued

### DIFF
--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -137,7 +137,7 @@ module Admin
       authorize(@loan, :statement_access?)
       @start_date = Date.parse(params[:start_date]) #Time.zone.today.last_year.beginning_of_year
       @end_date = Date.parse(params[:end_date]) #Time.zone.today.last_year.end_of_year
-      @transactions = @loan.transactions.in_date_range(@start_date, @end_date).most_recent_first.reverse
+      @transactions = @loan.transactions.in_date_range(@start_date, @end_date).standard_order
       @print_view = true
       @for_statement = true
       @is_draft = @loan.division.shared_closed_books_date.nil? || @end_date > @loan.division.shared_closed_books_date

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -184,18 +184,15 @@ class Loan < Project
     transactions.by_type("repayment").in_date_range(start_date, end_date).map { |t| t.change_in_interest }.sum
   end
 
-  def total_interest_repaid(start_date, end_date)
-    return repayments_of_interest(start_date: start_date, end_date: end_date) * -1
-  end
-
   def repayments_of_principal(start_date: nil, end_date: nil)
     return nil if transactions.standard_order.in_date_range(start_date, end_date).empty?
     transactions.by_type("repayment").in_date_range(start_date, end_date).map { |t| t.change_in_principal }.sum
   end
 
-  def accrued_interest(start_date: nil, end_date: nil)
+  def total_accrued_interest(start_date: nil, end_date: nil)
     return nil if transactions.standard_order.in_date_range(start_date, end_date).empty?
-    transactions.by_type("interest").in_date_range(start_date, end_date).map { |t| t.change_in_interest }.sum
+    txns_that_accrued_interest = transactions.in_date_range(start_date, end_date).select { |t| t.change_in_interest && t.change_in_interest > 0 }
+    txns_that_accrued_interest.map { |t| t.change_in_interest }.sum
   end
 
   def change_in_interest(start_date: nil, end_date: nil)

--- a/app/models/standard_loan_data_export.rb
+++ b/app/models/standard_loan_data_export.rb
@@ -89,7 +89,7 @@ class StandardLoanDataExport < DataExport
       sum_of_repayments: loan.sum_of_repayments(start_date: start_date, end_date: end_date),
       repayments_of_principal: loan.repayments_of_principal(start_date: start_date, end_date: end_date),
       repayments_of_interest: loan.repayments_of_interest(start_date: start_date, end_date: end_date),
-      accrued_interest: loan.accrued_interest(start_date: start_date, end_date: end_date),
+      accrued_interest: loan.total_accrued_interest(start_date: start_date, end_date: end_date),
       change_in_principal: loan.change_in_principal(start_date: start_date, end_date: end_date),
       change_in_interest: loan.change_in_interest(start_date: start_date, end_date: end_date),
       final_principal_balance: loan.final_principal_balance(start_date: start_date, end_date: end_date),

--- a/app/views/admin/loans/statement.html.slim
+++ b/app/views/admin/loans/statement.html.slim
@@ -21,7 +21,7 @@ div.statement
       // the following value is estimated, because it is total of change in interest in all txns Madeline classifies as repayments
       // it is possible that an organization could repay interest outside of these transactions (e.g. "other")
       // but not all changes in interest across all txn types are repayments of interest either
-      p #{t("statement.estimated_interest_repaid")}: #{format_currency(@loan.total_interest_repaid(@start_date, @end_date), @loan.currency, tooltip: false, show_country: false)}
+      p #{t("statement.total_interest_accrued")}: #{format_currency(@loan.total_interest_accrued(@start_date, @end_date), @loan.currency, tooltip: false, show_country: false)}
 
   - if @is_draft
     div.draft-warning

--- a/app/views/admin/loans/statement.html.slim
+++ b/app/views/admin/loans/statement.html.slim
@@ -21,7 +21,7 @@ div.statement
       // the following value is estimated, because it is total of change in interest in all txns Madeline classifies as repayments
       // it is possible that an organization could repay interest outside of these transactions (e.g. "other")
       // but not all changes in interest across all txn types are repayments of interest either
-      p #{t("statement.total_interest_accrued")}: #{format_currency(@loan.total_interest_accrued(@start_date, @end_date), @loan.currency, tooltip: false, show_country: false)}
+      p #{t("statement.total_accrued_interest")}: #{format_currency(@loan.total_accrued_interest(start_date: @start_date, end_date: @end_date), @loan.currency, tooltip: false, show_country: false)}
 
   - if @is_draft
     div.draft-warning

--- a/config/locales/en/statement.en.yml
+++ b/config/locales/en/statement.en.yml
@@ -3,7 +3,7 @@ en:
     annual: "%{year} Statement"
     contract_loan_amount: "Contract Loan Amount"
     draft_warning: "WARNING: This is a DRAFT. Information subject to change."
-    estimated_interest_repaid: "Estimated Interest Repaid"
+    total_interest_accrued: "Total Interest Accrued"
     historical: "Historical Loan Schedule"
     interest_rate: "Interest Rate"
     last_year_statement: "Statement for Last Year"

--- a/config/locales/en/statement.en.yml
+++ b/config/locales/en/statement.en.yml
@@ -3,7 +3,7 @@ en:
     annual: "%{year} Statement"
     contract_loan_amount: "Contract Loan Amount"
     draft_warning: "WARNING: This is a DRAFT. Information subject to change."
-    total_interest_accrued: "Total Interest Accrued"
+    total_accrued_interest: "Total Interest Accrued"
     historical: "Historical Loan Schedule"
     interest_rate: "Interest Rate"
     last_year_statement: "Statement for Last Year"

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -268,13 +268,14 @@ describe Loan, type: :model do
       end
     end
 
-    describe 'calculated fields: .sum_of_repayments, .sum_of_disbursements, .change_in_interest, .change_in_principal, .total_interest_repaid' do
+    describe 'calculated fields: .sum_of_repayments, .sum_of_disbursements, .change_in_interest, .change_in_principal, .total_interest_accrued' do
       context "no transactions" do
         it "returns nil" do
           expect(loan.sum_of_disbursements).to be_nil
           expect(loan.sum_of_repayments).to be_nil
           expect(loan.change_in_interest).to be_nil
           expect(loan.change_in_principal).to be_nil
+          expect(loan.total_accrued_interest).to be_nil
         end
       end
 
@@ -327,9 +328,9 @@ describe Loan, type: :model do
           expect(loan.change_in_principal(start_date: Date.parse('2019-01-03'), end_date: Date.parse('2019-01-05'))).to eq 14
           expect(loan.change_in_interest(end_date: Date.parse('2019-01-05'))).to eq 0.3
           expect(loan.change_in_principal(end_date: Date.parse('2019-01-05'))).to eq 13
-          expect(loan.total_interest_repaid(Date.parse('2018-01-01'), Date.parse('2020-01-01'))).to eq(1.2)
-          expect(loan.total_interest_repaid(Date.parse('2019-01-04'), Date.parse('2020-01-01'))).to eq(1.0)
-          expect(loan.total_interest_repaid(Date.parse('2019-01-05'), Date.parse('2020-01-01'))).to eq(0.6)
+          expect(loan.total_accrued_interest(start_date: Date.parse('2018-01-01'), end_date: Date.parse('2020-01-01'))).to eq(0.9)
+          expect(loan.total_accrued_interest(start_date: Date.parse('2019-01-04'), end_date: Date.parse('2020-01-01'))).to eq(0.5)
+          expect(loan.total_accrued_interest(start_date: Date.parse('2019-01-05'), end_date: Date.parse('2020-01-01'))).to eq(0.5)
         end
 
         it "raises error if at least one transaction has nil value for change_in_interest" do

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -33,9 +33,9 @@ describe Question, :type => :model do
     end
 
     context "when questions from different divisions are present" do
-      let!(:div_a1) { create(:division, parent: root_division) }
-      let!(:div_b) { create(:division, parent: div_a1) }
-      let!(:div_a2) { create(:division, parent: root_division) }
+      let!(:div_a1) { create(:division, parent: root_division, name: "a1") }
+      let!(:div_b) { create(:division, parent: div_a1, name: "b") }
+      let!(:div_a2) { create(:division, parent: root_division, name: "a2") }
 
       context "when no questions from same division depth are present" do
         let!(:f33) { create_question(set: set, division: div_b, parent: f3, name: "f33", type: "text") }
@@ -198,9 +198,9 @@ describe Question, :type => :model do
 
   describe "validations" do
     describe "group division depth check" do
-      let!(:div_a) { create(:division, parent: root_division) }
-      let!(:div_b) { create(:division, parent: div_a) }
-      let!(:div_c) { create(:division, parent: div_b) }
+      let!(:div_a) { create(:division, parent: root_division, name: "div_a") }
+      let!(:div_b) { create(:division, parent: div_a, name: "div_b") }
+      let!(:div_c) { create(:division, parent: div_b, name: "div_c") }
       let!(:set) { create(:question_set) }
       let!(:group) { create_question(set: set, parent: set.root_group, division: div_b, type: "group") }
       subject(:question) do

--- a/spec/system/admin/accounting/transaction_flow_spec.rb
+++ b/spec/system/admin/accounting/transaction_flow_spec.rb
@@ -180,10 +180,10 @@ describe "transaction flow", :accounting do
     end
 
     describe "filter transactions" do
-      let!(:txns_new) { create_list(:accounting_transaction, 2, description: "new txn", project: loan, txn_date: Time.zone.now) }
-      let!(:txn_old) { create_list(:accounting_transaction, 2, description: "old txn", project: loan, txn_date: 1.year.ago) }
-      let!(:beginning_of_year) { Time.zone.now.beginning_of_year }
-      let!(:end_of_year) { Time.zone.now.end_of_year }
+      let!(:txns_new) { create_list(:accounting_transaction, 2, description: "new txn", project: loan, txn_date: Date.parse("2020-03-01")) }
+      let!(:txn_old) { create_list(:accounting_transaction, 2, description: "old txn", project: loan, txn_date: Date.parse("2019-03-01")) }
+      let!(:beginning_of_year) { Date.parse("2020-01-01") }
+      let!(:end_of_year) { Date.parse("2020-12-31")}
 
       scenario "show only transactions from current year" do
         visit "/admin/loans/#{loan.id}/transactions"

--- a/spec/system/admin/accounting/transaction_flow_spec.rb
+++ b/spec/system/admin/accounting/transaction_flow_spec.rb
@@ -180,8 +180,8 @@ describe "transaction flow", :accounting do
     end
 
     describe "filter transactions" do
-      let!(:txns_new) { create_list(:accounting_transaction, 2, description: "new", project: loan, txn_date: Time.zone.now) }
-      let!(:txn_old) { create_list(:accounting_transaction, 2, description: "old", project: loan, txn_date: 1.year.ago) }
+      let!(:txns_new) { create_list(:accounting_transaction, 2, description: "new txn", project: loan, txn_date: Time.zone.now) }
+      let!(:txn_old) { create_list(:accounting_transaction, 2, description: "old txn", project: loan, txn_date: 1.year.ago) }
       let!(:beginning_of_year) { Time.zone.now.beginning_of_year }
       let!(:end_of_year) { Time.zone.now.end_of_year }
 
@@ -192,8 +192,8 @@ describe "transaction flow", :accounting do
         fill_in "transactions_f_txn_date_fr", with: beginning_of_year
         fill_in "transactions_f_txn_date_to", with: end_of_year
         click_on "Filter"
-        expect(page).to have_content "new"
-        expect(page).not_to have_content "old"
+        expect(page).to have_content "new txn"
+        expect(page).not_to have_content "old txn"
       end
     end
 


### PR DESCRIPTION
last minute changes: 
- interest accrued instead of interest paid (NOTE: this update also affects the "Interest Accrued" column in standard loan data exports. Previously it calced only change in interest from interest-type txns. Update is all + change in interest on any type of txn, including Other etc. 
- use existing scope to make sure repayments displayed after interest on same day, and a statement should have $0.00  bal in last line on a finished loan